### PR TITLE
Fix deploy action #46

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   deploy:
     name: Deploy to cloud.gov
-    needs: build_and_test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,83 @@
 name: Deploy
 
 on:
-   workflow_run:
-    workflows: ["Test"]
-    branches: [main]
-    types: 
-      - completed
+  push:
+    branches: [ main ]
 
 jobs:
+  build_and_test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: all_sorns
+          POSTGRES_DB: all_sorns_test
+          POSTGRES_PASSWORD: postgres
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7.x
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.13.0
+      - name: Cache npm dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Cache gems
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Install linux dependencies
+        run: |
+          sudo apt-get -yqq install libpq-dev build-essential libcurl4-openssl-dev
+      - name: install ruby dependencies
+        run: |
+          bundle install --jobs 4 --retry 3
+      - name: install javascript dependencies
+        run: yarn install
+      - name: Setup test database
+        env:
+          RAILS_ENV: test
+          PGHOST: localhost
+          POSTGRES_DB: all_sorns_test
+          POSTGRES_USER: all_sorns
+          POSTGRES_PASSWORD: postgres
+        run: |
+          cp config/database.ci.yml config/database.yml
+          rake db:create db:migrate
+
+      - name: Run rails tests
+        env:
+          PGHOST: localhost
+          POSTGRES_DB: all_sorns_test
+          POSTGRES_USER: all_sorns
+          POSTGRES_PASSWORD: postgres
+          PGPORT: ${{ job.services.postgres.ports[5432] }}
+          RAILS_ENV: test
+        run: rspec
+
   deploy:
     name: Deploy to cloud.gov
+    needs: build_and_test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -31,5 +99,5 @@ jobs:
           CF_SPACE: ${{ secrets.CF_SPACE }}
           CF_CGHOSTNAME: test
         run: |
-          ./.cloud-gov/deploy.sh 
+          ./.cloud-gov/deploy.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build_and_test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,4 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
-
-name: Test
-
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 
 jobs:
   build_and_test:
@@ -30,13 +17,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
-      # if you need redis
-      # redis:
-      #   image: redis
-      #   ports:
-      #   - 6379:6379
-      #   options: --entrypoint redis-server
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Github Actions is still pretty new. We can just duplicate the code for running the specs in both of the workflows.

I found an https://github.com/lewagon/wait-on-check-action which would work too, but who knows how long it would work for.