### PR TITLE
Fix system name parsing error. Closes #47

### DIFF
--- a/app/models/sorn_xml_parser.rb
+++ b/app/models/sorn_xml_parser.rb
@@ -72,13 +72,15 @@ class SornXmlParser
 
   def get_system_name
     bracketed_name = find_section('SYSTEM NAME')
-    system_name = bracketed_name.join(', ')
-    system_name = system_name.sub ', {}', ''
-    system_name = system_name.sub '"]', ''
-    system_name = system_name.sub '["', ''
-    system_name = system_name.sub '"', ''
-    puts system_name
-    return system_name
+    if bracketed_name
+      system_name = bracketed_name.join(', ')
+      system_name = system_name.sub ', {}', ''
+      system_name = system_name.sub '"]', ''
+      system_name = system_name.sub '["', ''
+      system_name = system_name.sub '"', ''
+      puts system_name
+      return system_name
+    end
   end
 
   def get_system_number

--- a/spec/fixtures/files/cma-sorn.xml
+++ b/spec/fixtures/files/cma-sorn.xml
@@ -1,0 +1,59 @@
+
+<NOTICE>
+      <PREAMB>
+        <AGENCY TYPE="N">DEPARTMENT OF VETERANS AFFAIRS</AGENCY>
+        <SUBJECT>Privacy Act of 1974; Matching Program</SUBJECT>
+        <AGY>
+          <HD SOURCE="HED">AGENCY:</HD>
+          <P>Department of Veterans Affairs (VA).</P>
+        </AGY>
+        <ACT>
+          <HD SOURCE="HED">ACTION:</HD>
+          <P>Notice of a new matching program.</P>
+        </ACT>
+        <SUM>
+          <HD SOURCE="HED">SUMMARY:</HD>
+          <P>This re-established computer matching agreement (CMA) sets forth the terms, conditions, and safeguards under which the Internal Revenue Service (IRS) will disclose return information, relating to unearned income, to the Department of Veterans Affairs (VA), Veterans Benefits Administration (VBA) for the Disclosure of Information to Federal, State and Local Agencies (DIFSLA). The purpose of this CMA is to make available to VBA certain return information needed to determine eligibility for, and amount of benefits for, VBA applicants and beneficiaries of needs-based benefits, and to adjust income-dependent benefit payments, as prescribed by law. Currently, the most cost effective and efficient way to verify annual income of applicants, and recipients of these benefits, is through a computer match.</P>
+        </SUM>
+        <DATES>
+          <HD SOURCE="HED">DATES:</HD>
+
+          <P>Comments on this matching notice must be received no later than 30 days after date of publication in the <E T="04">Federal Register</E>. If no public comments are received during the period allowed for comment, the re-established agreement will become effective January 1, 2021 provided it is a minimum of 30 days after the publication date. If VA receives public comments, VA shall review the substance of the comments to determine whether or not VA needs to take other actions. The CMA will be effective 30 days after the publication date even, if public comments are received. This matching program will be valid for 18 months from the effective date of this notice.</P>
+        </DATES>
+        <ADD>
+          <HD SOURCE="HED">ADDRESSES:</HD>
+          <P>Comments may be submitted through <E T="03">www.Regulations.gov</E> or mailed to VA Privacy Service, 810 Vermont Avenue NW, (005R1A), Washington, DC 20420. Comments should indicate that they are submitted <PRTPAGE P="73357"/>in response to VBA DIFSLA Matching Agreement. Comments received will be available at regulations.gov for public viewing, inspection or copies.</P>
+        </ADD>
+        <FURINF>
+          <HD SOURCE="HED">FOR FURTHER INFORMATION CONTACT:</HD>
+          <P>Victor D. Hall, Program Analyst, Pension and Fiduciary Service (21P), Department of Veterans Affairs, 810 Vermont Ave. NW, Washington, DC 20420, (202) 461-8394.</P>
+        </FURINF>
+      </PREAMB>
+      <SUPLINF>
+        <HD SOURCE="HED">SUPPLEMENTARY INFORMATION:</HD>
+        <P>CMA between VA and IRS DIFSLA, expires December 31, 2020. VBA has a legal obligation to reduce the amount of pension and of parents' dependency and indemnity compensation by the amount of annual income received by the VBA beneficiary. VA will use this information to verify the income information submitted by beneficiaries in VA's needs-based benefit programs and adjust VA benefit payments as prescribed by law. By comparing the information received through the matching program between VBA and IRS, VBA will be able to timely and accurately adjust benefit amounts. The match information will help VBA minimize overpayments and deter fraud and abuse. The legal authority to conduct this match is 38 U.S.C. 5106, which requires any Federal department or agency to provide VA such information as VA requests for the purposes of determining eligibility for benefits, or verifying other information with respect to payment of benefits. The VA records involved in the match are in “Compensation, Pension, Education, and Vocational and Rehabilitation and Employment Records—VA (58 VA 21/22/28),” a system of records which was first published at 41 FR 9294 (March 3, 1976), amended and republished in its entirety at 77 FR 42593 (July 19, 2012). The IRS records consist of information from the system records identified as will extract return information with respect to unearned income of the VBA applicant or beneficiary and (when applicable) of such individual's spouse from the Information Return Master File (IRMF), Treasury/IRS 22.061, at 80 FR 54081- 082 (September 8, 2015). In accordance with the Privacy Act, 5 U.S.C. 552a(o)(2) and (r), copies of the agreement are being sent to both Houses of Congress and to the Office of Management and Budget. This notice is provided in accordance with the provisions of Privacy Act of 1974 as amended by Public Law 100-503.</P>
+        <PRIACT>
+          <HD SOURCE="HD2">PARTICIPATING AGENCIES: </HD>
+          <P>The Internal Revenue Service (IRS).</P>
+          <HD SOURCE="HD2">AUTHORITY FOR CONDUCTING THE MATCHING PROGRAM: </HD>
+          <P>The Privacy Act, 5 U.S.C. 552a, and 38 U.S.C. 6103 authorize VA to enter into this CMA with IRS.</P>
+          <HD SOURCE="HD2">PURPOSE(S): </HD>
+          <P>To re-establish a CMA with IRS to provide VBA with certain return information needed to determine eligibility for and amount of benefits for VBA applicants and beneficiaries of needs-based benefits and to adjust income-dependent benefit payments as prescribed by law.</P>
+          <HD SOURCE="HD2">CATEGORIES OF INDIVIDUALS: </HD>
+          <P>Veterans and beneficiaries who apply for VA income benefits.</P>
+          <HD SOURCE="HD2">CATEGORIES OF RECORDS: </HD>
+          <P>VBA will furnish the IRS with records in accordance with the current IRS Publication 3373, DIFSLA Handbook. The requests from VBA will include: The Social Security Number (SSN) and name Control (first four characters of the surname) for each individual for whom unearned income information is requested. IRS will provide a response record for each individual identified by VBA. The total number of records will be equal to or greater than the number of records submitted by VBA. In some instances, an individual may have more than one record on file. When there is a match of individual SSN and name control, IRS will disclose the following to VBA: Payee account number; payee name and mailing address; payee TIN; payer name and address; payer TIN; and income type and amount.</P>
+          <HD SOURCE="HD2">SYSTEM(S) OF RECORDS: </HD>
+          <P>VBA records involved in this match are in “VA Compensation, Pension, Education, and Vocational Rehabilitation and Employment Records—VA” (58 VA 21/22/28), a system of records that was first published at 41 FR 9294 (March 3, 1976), amended and republished in its entirety at 77 FR 42593 (July 19, 2012). IRS will extract return information with respect to unearned income of the VBA applicant or beneficiary and (when applicable) of such individual's spouse from the Information Return Master File (IRMF), Treasury/IRS 22.061, as published at 80 FR 54081-082 (September 8,2015).</P>
+          <HD SOURCE="HD2">Signing Authority</HD>
+          <P>The Senior Agency Official for Privacy, or designee, approved this document and authorized the undersigned to sign and submit the document to the Office of the Federal Register for publication electronically as an official document of the Department of Veterans Affairs. Joseph S. Stenaka, Executive Director for Information Security Operations and Chief Privacy Officer, approved this document on October 20, 2020 for publication.</P>
+        </PRIACT>
+        <SIG>
+          <DATED>Dated: November 12, 2020.</DATED>
+          <NAME>Amy L. Rose,</NAME>
+          <TITLE>Program Analyst,  VA Privacy Service, Office of Information Security, Office of Information and Technology, Department of Veterans Affairs.</TITLE>
+        </SIG>
+      </SUPLINF>
+      <FRDOC>[FR Doc. 2020-25333 Filed 11-16-20; 8:45 am]</FRDOC>
+      <BILCOD>BILLING CODE 8320-01-P</BILCOD>
+    </NOTICE>

--- a/spec/models/sorn_spec.rb
+++ b/spec/models/sorn_spec.rb
@@ -77,6 +77,18 @@ RSpec.describe Sorn, type: :model do
         expect(sorn).not_to have_received(:update)
       end
     end
+
+    context "with unparseable system name" do
+      let(:sorn) do
+        xml = file_fixture("cma-sorn.xml").read
+        create(:sorn, xml: xml)
+      end
+
+      it "doesn't raise an error" do
+        expect{ sorn.parse_xml }.not_to raise_error
+      end
+
+    end
   end
 
   describe ".update_mentioned_sorns" do


### PR DESCRIPTION
Computer matching agreements and other SORNs without a system name section were blowing up our parsing. This fixes that bug and lets parsing continue.

<img width="439" alt="Screen Shot 2020-11-18 at 12 01 15 PM" src="https://user-images.githubusercontent.com/595778/99581531-cbbd9f80-2995-11eb-8441-612bfb4fe22f.png">
<img width="400" alt="Screen Shot 2020-11-18 at 12 01 19 PM" src="https://user-images.githubusercontent.com/595778/99581552-cf512680-2995-11eb-96fc-d44c29618a3f.png">

Addresses #47 
