### PR TITLE
Stop retrying jobs with errors.

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -1,0 +1,1 @@
+GoodJob.retry_on_unhandled_error = false


### PR DESCRIPTION
We fixed a parsing bug in #54, we noticed though that that bug was stopping other later jobs from running. This PR fixes that downstream problem.

https://github.com/bensheldon/good_job#global-options

We had 6000+ jobs still in our queue, from the #54 bug. This PR will make those not stick around.