### PR TITLE
Have Office of Secretary component agency show up.

### DIFF
--- a/app/controllers/sorns_controller.rb
+++ b/app/controllers/sorns_controller.rb
@@ -1,6 +1,6 @@
 class SornsController < ApplicationController
   def search
-    @sorns = Sorn.no_computer_matching.includes(:agencies)
+    @sorns = Sorn.no_computer_matching.includes(:mentioned).preload(:agencies)
 
     if no_params_on_page_load?
       # return all sorns with default fields

--- a/app/models/federal_register_client.rb
+++ b/app/models/federal_register_client.rb
@@ -44,6 +44,8 @@ class FederalRegisterClient
     handle_result(result)
   end
 
+  private
+
   def handle_result(result)
     sorn = Sorn.find_by(citation: result.citation)
 
@@ -59,8 +61,6 @@ class FederalRegisterClient
 
     UpdateSornJob.perform_later(sorn.id)
   end
-
-  private
 
   def a_sorn_title?(title)
     # We researched all Federal Register search result titles

--- a/app/models/federal_register_client.rb
+++ b/app/models/federal_register_client.rb
@@ -53,13 +53,9 @@ class FederalRegisterClient
       sorn.update(**params)
     else
       sorn = Sorn.create(params)
-
-      # Create agencies
-      result.agencies.each do |api_agency|
-        agency = Agency.find_or_create_by(name: api_agency.name, api_id: api_agency.id, parent_api_id: api_agency.parent_id)
-        sorn.agencies << agency
-      end
     end
+
+    update_agencies(result, sorn)
 
     UpdateSornJob.perform_later(sorn.id)
   end
@@ -88,5 +84,20 @@ class FederalRegisterClient
       agency_names: result.agency_names,
       data_source: :fedreg
     }
+  end
+
+  def update_agencies(result, sorn)
+    # Create agencies
+    result.agencies.each do |api_agency|
+      if api_agency.raw_name == "Office of the Secretary"
+        # A popular component used by the DoD
+        # doesn't have the other metadata
+        agency = Agency.find_or_create_by(name: api_agency.raw_name, api_id: 9999, parent_api_id: 103)
+      else
+        agency = Agency.find_or_create_by(name: api_agency.name, api_id: api_agency.id, parent_api_id: api_agency.parent_id)
+      end
+
+      sorn.agencies << agency if sorn.agencies.exclude? agency
+    end
   end
 end

--- a/app/models/sorn.rb
+++ b/app/models/sorn.rb
@@ -8,7 +8,7 @@ class Sorn < ApplicationRecord
   include PgSearch::Model
   validates :citation, uniqueness: true
 
-  scope :no_computer_matching, -> { where.not('action ILIKE ?', '%matching%') }
+  scope :no_computer_matching, -> { where.not('"sorns"."action" ILIKE ?', '%matching%') }
 
   default_scope { order(publication_date: :desc) }
 

--- a/spec/models/federal_register_client_spec.rb
+++ b/spec/models/federal_register_client_spec.rb
@@ -25,10 +25,7 @@ RSpec.describe FederalRegisterClient, type: :model do
           "parent_id": nil
         ),
         OpenStruct.new(
-          "raw_name": "FAKE CHILD AGENCY",
-          "name": "Fake Child Agency",
-          "id": 2,
-          "parent_id": 1
+          "raw_name": "Office of the Secretary"
         )
       ],
       agency_names: ["Fake Parent Agency", "Fake Child Agency"]
@@ -55,6 +52,22 @@ RSpec.describe FederalRegisterClient, type: :model do
 
       it "Creates agencies for each result" do
         expect{ client.find_sorns }.to change{ Agency.count }.by 2
+        expect(Sorn.last.agencies.first.name).to eq "Fake Parent Agency"
+        expect(Sorn.last.agencies.second.name).to eq "Office of the Secretary"
+      end
+
+      context "with existing agencies" do
+        let(:sorn) { create :sorn, agencies: [] }
+
+        before do
+          sorn.agencies << Agency.create(name: "Fake Parent Agency", api_id: 1, parent_api_id: nil)
+          sorn.agencies << Agency.create(name: "Office of the Secretary", api_id: 9999, parent_api_id: 103)
+        end
+
+        it "Doesn't duplicate agencies" do
+          client.find_sorns
+          expect(sorn.agencies.count).to eq 2
+        end
       end
 
       it "has the expected attributes" do


### PR DESCRIPTION
The DoD's Office of the Secretary has 1463 SORNs, but the metadata is a little weird in the Federal Register API. This PR gets it show up correctly.

<img width="451" alt="Screen Shot 2020-11-18 at 4 51 50 PM" src="https://user-images.githubusercontent.com/595778/99606338-6500ac00-29be-11eb-937f-767e216f18bd.png">

This PR also:
-  Improves when and how agencies get created
- When filtering by an agency, its components or parent agency also show up on the SORN
- More efficient queries for sorns, agencies, and mentioned sorns.