### PR TITLE
Add categories to the default search

### DIFF
--- a/app/models/sorn.rb
+++ b/app/models/sorn.rb
@@ -57,6 +57,8 @@ class Sorn < ApplicationRecord
     'action',
     'system_name',
     'summary',
+    'categories_of_individuals',
+    'categories_of_record',
     'html_url',
     'publication_date'
   ]

--- a/spec/requests/search_csv_request_spec.rb
+++ b/spec/requests/search_csv_request_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Search csv", type: :request do
     let(:agency) { nil }
 
     it "returns eveything with the default columns" do
-      expect(response.body).to eq "agency_names,action,system_name,summary,html_url,publication_date\n\"[\"\"FAKE AGENCY NAMES\"\"]\",FAKE ACTION,FAKE SYSTEM NAME,FAKE SUMMARY,HTML URL,2000-01-13\n"
+      expect(response.body).to eq "agency_names,action,system_name,summary,categories_of_individuals,categories_of_record,html_url,publication_date\n\"[\"\"FAKE AGENCY NAMES\"\"]\",FAKE ACTION,FAKE SYSTEM NAME,FAKE SUMMARY,,,HTML URL,2000-01-13\n"
     end
   end
 


### PR DESCRIPTION
per user research and observations default checks `categories of record` and `categories of individuals` in the search results.