### PR TITLE
Migrate db on deploy

### DIFF
--- a/.cloud-gov/manifest-dev.yml
+++ b/.cloud-gov/manifest-dev.yml
@@ -6,3 +6,4 @@
     memory: 512MB
     services:
       - all-sorns-db-dev
+    command: bundle exec rake cf:on_first_instance db:migrate && bundle exec rails s -p $PORT -e $RAILS_ENV

--- a/.cloud-gov/manifest.yml
+++ b/.cloud-gov/manifest.yml
@@ -6,3 +6,4 @@
     memory: 512MB
     services:
       - all-sorns-db
+    command: bundle exec rake cf:on_first_instance db:migrate && bundle exec rails s -p $PORT -e $RAILS_ENV

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,11 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
+
+namespace :cf do
+    desc "Only run on the first application instance"
+    task :on_first_instance do
+      instance_index = JSON.parse(ENV["VCAP_APPLICATION"])["instance_index"] rescue nil
+      exit(0) unless instance_index == 0
+    end
+  end

--- a/Rakefile
+++ b/Rakefile
@@ -5,10 +5,3 @@ require_relative 'config/application'
 
 Rails.application.load_tasks
 
-namespace :cf do
-    desc "Only run on the first application instance"
-    task :on_first_instance do
-      instance_index = JSON.parse(ENV["VCAP_APPLICATION"])["instance_index"] rescue nil
-      exit(0) unless instance_index == 0
-    end
-  end

--- a/lib/tasks/all_sorns.rake
+++ b/lib/tasks/all_sorns.rake
@@ -36,3 +36,11 @@ namespace :repair do
     end
   end
 end
+
+namespace :cf do
+  desc "Only run on the first application instance"
+  task :on_first_instance do
+    instance_index = JSON.parse(ENV["VCAP_APPLICATION"])["instance_index"] rescue nil
+    exit(0) unless instance_index == 0
+  end
+end


### PR DESCRIPTION
Use CloudFoundry's [Tips for ruby developers](https://docs.cloudfoundry.org/buildpacks/ruby/ruby-tips.html) to update the run cmd on the manifests and create a rake task that only will run the task once per deploy (given that db is a shared resource)