### PR TITLE
Remove turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'sass-rails', '>= 6'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 4.0'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,9 +245,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     web-console (4.0.4)
@@ -301,7 +298,6 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   web-console (>= 3.3.0)
   webdrivers
   webpacker (~> 4.0)

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,7 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-require("turbolinks").start()
+// require("turbolinks").start()
 require("jquery")
 
 window.dataLayer = window.dataLayer || [];

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,8 +14,8 @@
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-QZ9W5STPKJ"></script>
 
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%= javascript_pack_tag 'application' %>
     <%= javascript_pack_tag 'search' %>
 
  </head>

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.3.0",
     "jquery": "^3.5.1",
-    "node-forge": "^0.10.0",
-    "turbolinks": "^5.2.0"
+    "node-forge": "^0.10.0"
   },
   "version": "0.1.0",
   "devDependencies": {

--- a/spec/factories/sorn.rb
+++ b/spec/factories/sorn.rb
@@ -11,6 +11,12 @@ FactoryBot.define do
     xml_url { "xml_url" }
     xml { nil }
     data_source { 'fedreg' }
-    agencies { [ association(:agency),  association(:agency, name: "Fake Child Agency")] }
+
+    agencies do
+      [
+        Agency.find_or_create_by(name: "Fake Parent Agency"),
+        Agency.find_or_create_by(name: "Fake Child Agency")
+      ]
+    end
   end
 end

--- a/spec/factories/sorn.rb
+++ b/spec/factories/sorn.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     action { "FAKE ACTION" }
     summary { "FAKE SUMMARY" }
     system_name { "FAKE SYSTEM NAME" }
-    citation { 'citation' }
+    sequence(:citation) { |n| "FAKE CITATION #{n}" }
     publication_date { "2000-01-13"}
     html_url { "HTML URL" }
     xml_url { "xml_url" }

--- a/spec/models/federal_register_client_spec.rb
+++ b/spec/models/federal_register_client_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe FederalRegisterClient, type: :model do
       pdf_url: "pdf url",
       full_text_xml_url: "expected url",
       html_url: "html url",
-      citation: "citation",
+      citation: "FAKE CITATION 1",
       type: type,
       publication_date: "2000-01-13",
       agencies: [
@@ -80,7 +80,7 @@ RSpec.describe FederalRegisterClient, type: :model do
         expect(sorn.agency_names).to eq 'Fake Parent Agency | Fake Child Agency'
         expect(sorn.action).to eq 'api action'
         expect(sorn.dates).to eq 'api dates'
-        expect(sorn.citation).to eq 'citation'
+        expect(sorn.citation).to eq 'FAKE CITATION 1'
         expect(sorn.xml_url).to eq 'expected url'
         expect(sorn.html_url).to eq 'html url'
         expect(sorn.pdf_url).to eq 'pdf url'
@@ -127,7 +127,7 @@ RSpec.describe FederalRegisterClient, type: :model do
     end
 
     context "with existing SORN" do
-      let!(:sorn) { create :sorn, xml_url: nil }
+      let!(:sorn) { create :sorn, citation: "FAKE CITATION 1", xml_url: nil }
 
       it "updates existing SORN" do
         expect{ client.find_sorns; sorn.reload }.to change{ sorn.xml_url }.from(nil).to('expected url')

--- a/spec/requests/search_csv_request_spec.rb
+++ b/spec/requests/search_csv_request_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Search csv", type: :request do
-  let!(:sorn) { create :sorn }
+  let!(:sorn) { create :sorn, citation: "citation" }
 
   before { get "/search.csv?search=#{search}&#{fields}&#{agency}" }
 

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Search", type: :request do
-  let!(:sorn) { create :sorn }
+  let!(:sorn) { create :sorn, citation: "citation" }
 
   before { get "/search?search=#{search}&#{fields}&#{agency}" }
 

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "/search", type: :system do
   before do
     driven_by(:selenium_chrome)#_headless)
-    create :sorn
+    11.times { create :sorn }
   end
 
   it "default checkboxes are as expected" do
@@ -18,7 +18,6 @@ RSpec.describe "/search", type: :system do
 
   it "selected agencies are still checked after a search" do
     visit "/search?agencies[]=Fake+Parent+Agency&fields[]=system_name"
-
     expect(find("#agencies-fake-parent-agency")).to be_checked
   end
 
@@ -29,10 +28,10 @@ RSpec.describe "/search", type: :system do
   end
 
   scenario "paging doesn't break js" do
-    it "goes to second page and have js still work" do
-      visit root
-
-      binding.pry
-    end
+    visit "/"
+    find_all("nav.pagination").first.find_all(".page")[1].click
+    sleep 1
+    # gov banner should remain closed
+    expect(find("#gov-banner").visible?).to be_falsey
   end
 end

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "/search", type: :system do
   before do
-    driven_by(:selenium_chrome)#_headless)
+    driven_by(:selenium_chrome_headless)
     11.times { create :sorn }
   end
 

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "/search", type: :system do
   before do
-    driven_by(:selenium_chrome_headless)
+    driven_by(:selenium_chrome)#_headless)
     create :sorn
   end
 
@@ -26,5 +26,13 @@ RSpec.describe "/search", type: :system do
     visit "/search"
 
     expect(page).to have_css '.agency-separator'
+  end
+
+  scenario "paging doesn't break js" do
+    it "goes to second page and have js still work" do
+      visit root
+
+      binding.pry
+    end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -7146,11 +7146,6 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-turbolinks@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
-  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
-
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"


### PR DESCRIPTION
This PR removes turbolinks, which fixes #69 

We weren't using turbolinks for anything, so our page isn't any slower. The code base is simpler. On older, slower browsers, the user may see a whole page refresh when searching. Thats fine and they are used to.

To get a good test for it, I reworked how our sorn factories work.

To try locally:
```
bundle install
rails tmp:cache:clear
```