### PR TITLE
Better agency names

### DIFF
--- a/app/models/federal_register_client.rb
+++ b/app/models/federal_register_client.rb
@@ -101,7 +101,7 @@ class FederalRegisterClient
 
   def build_agency(result, api_agency)
     if api_agency.name.present?
-      Agency.find_or_create_by(name: api_agency.name, api_id: api_agency.id, parent_api_id: api_agency.parent_id)
+      Agency.find_or_create_by(name: api_agency.raw_name.titleize, api_id: api_agency.id, parent_api_id: api_agency.parent_id)
     else dod_office_of_the_secretary?(result, api_agency)
       Agency.find_or_create_by(name: "Office of the Secretary", api_id: 9999, parent_api_id: 103)
     end

--- a/app/models/federal_register_client.rb
+++ b/app/models/federal_register_client.rb
@@ -6,7 +6,7 @@ class FederalRegisterClient
 
     # Find all available fields at
     # https://github.com/usnationalarchives/federal_register/blob/master/lib/federal_register/document.rb#L4
-    @fields = fields || ["action", "agencies", "agency_names", "citation",
+    @fields = fields || ["action", "agencies", "citation",
                         "dates", "full_text_xml_url", "html_url", "pdf_url",
                         "publication_date", "raw_text_url", "title", "type"]
 
@@ -72,7 +72,7 @@ class FederalRegisterClient
 
   def sorn_params(result)
     {
-      agency_names: result.agency_names.join(' | '),
+      agency_names: get_nice_agency_names(result),
       action: result.action,
       dates: result.dates,
       xml_url: result.full_text_xml_url,
@@ -98,6 +98,16 @@ class FederalRegisterClient
   end
 
   private
+
+  def get_nice_agency_names(result)
+    result.agencies.map do |api_agency|
+      if api_agency.name == "Office of the Secretary"
+        api_agency.name
+      else
+        api_agency.raw_name.titleize
+      end
+    end.join(" | ")
+  end
 
   def build_agency(result, api_agency)
     if api_agency.id.present? # skip the subcomponents without metadata

--- a/app/models/federal_register_client.rb
+++ b/app/models/federal_register_client.rb
@@ -100,11 +100,8 @@ class FederalRegisterClient
   private
 
   def build_agency(result, api_agency)
-    # return an agency
+    if api_agency.id.present? # skip the subcomponents without metadata
 
-    if api_agency.raw_name == "Office of the Secretary"
-      build_secretary_agency(result)
-    else
       # raw_name has a few typos and edge cases, so match on api_id, then add the name
       our_agency = Agency.find_by(api_id: api_agency.id, parent_api_id: api_agency.parent_id)
       if our_agency.present?
@@ -114,21 +111,5 @@ class FederalRegisterClient
         Agency.create(name: api_agency.raw_name.titleize, api_id: api_agency.id, parent_api_id: api_agency.parent_id)
       end
     end
-  end
-
-  def build_secretary_agency(result)
-    if office_of_the_secretary?(result, "Defense Department")
-      Agency.find_or_create_by(name: "Office of the Secretary, DoD", api_id: 9999, parent_api_id: 103)
-    elsif office_of_the_secretary?(result, "Interior Department")
-      Agency.find_or_create_by(name: "Office of the Secretary, DoI", api_id: 8888, parent_api_id: 253)
-    elsif office_of_the_secretary?(result, "Labor Department")
-      Agency.find_or_create_by(name: "Office of the Secretary, DoL", api_id: 7777, parent_api_id: 271)
-    elsif office_of_the_secretary?(result, "Transportation Department")
-      Agency.find_or_create_by(name: "Office of the Secretary, DoT", api_id: 6666, parent_api_id: 492)
-    end
-  end
-
-  def office_of_the_secretary?(result, agency_name)
-    result.agencies.select(&:name).any?{|a| a.name == agency_name }
   end
 end

--- a/app/views/sorns/search.html.erb
+++ b/app/views/sorns/search.html.erb
@@ -17,10 +17,10 @@
         <span class="usa-search__submit-text">Search</span>
       </button>
     </fieldset>
-  </div> 
+  </div>
 </section>
   <div class="grid-container margin-top-2">
-    
+
     <div class ="grid-row grid-gap">
       <div class="usa-layout-docs__sidenav grid-col-4">
         <div class="border border-gray-70 sidebar" id="sidebar">

--- a/spec/factories/agencies.rb
+++ b/spec/factories/agencies.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :agency do
-    name { "Fake Parent Agency" }
+    name { "Parent Agency" }
     api_id { 15 }
     parent_api_id { nil }
   end

--- a/spec/factories/sorn.rb
+++ b/spec/factories/sorn.rb
@@ -1,7 +1,7 @@
 # This will guess the User class
 FactoryBot.define do
   factory :sorn do
-    agency_names { 'Fake Parent Agency | Fake Child Agency' }
+    agency_names { 'Parent Agency | Child Agency' }
     action { "FAKE ACTION" }
     summary { "FAKE SUMMARY" }
     system_name { "FAKE SYSTEM NAME" }

--- a/spec/factories/sorn.rb
+++ b/spec/factories/sorn.rb
@@ -14,8 +14,8 @@ FactoryBot.define do
 
     agencies do
       [
-        Agency.find_or_create_by(name: "Fake Parent Agency"),
-        Agency.find_or_create_by(name: "Fake Child Agency")
+        Agency.find_or_create_by(name: "Parent Agency"),
+        Agency.find_or_create_by(name: "Child Agency")
       ]
     end
   end

--- a/spec/models/federal_register_client_spec.rb
+++ b/spec/models/federal_register_client_spec.rb
@@ -30,8 +30,7 @@ RSpec.describe FederalRegisterClient, type: :model do
           "id": 2,
           "parent_id": 1
         )
-      ],
-      agency_names: ["Fake Parent Agency", "Fake Child Agency"]
+      ]
     )
     result_set = double(FederalRegister::ResultSet, results: [mock_result], total_pages: pages)
     allow($stdout).to receive(:puts)
@@ -77,7 +76,7 @@ RSpec.describe FederalRegisterClient, type: :model do
         client.find_sorns
 
         sorn = Sorn.last
-        expect(sorn.agency_names).to eq 'Fake Parent Agency | Fake Child Agency'
+        expect(sorn.agency_names).to eq 'Parent Agency | Child Agency'
         expect(sorn.action).to eq 'api action'
         expect(sorn.dates).to eq 'api dates'
         expect(sorn.citation).to eq 'FAKE CITATION 1'
@@ -110,8 +109,7 @@ RSpec.describe FederalRegisterClient, type: :model do
               OpenStruct.new(
                 "raw_name": "Office of the Secretary"
               )
-            ],
-            agency_names: ["Defense Department", "Office of the Secretary"]
+            ]
           )
           result_set = double(FederalRegister::ResultSet, results: [mock_result], total_pages: pages)
           allow(FederalRegister::Document).to receive(:search).and_return result_set
@@ -121,6 +119,12 @@ RSpec.describe FederalRegisterClient, type: :model do
           expect{ client.find_sorns }.to change{ Agency.count }.by 1
 
           expect(Sorn.last.agencies.first).to have_attributes(name: "Department Of Defense", api_id: 103, parent_api_id: nil)
+        end
+
+        it "does write subcomponents to agency_names though" do
+          client.find_sorns
+
+          expect(Sorn.last.agency_names).to eq "Department Of Defense | Office Of The Secretary"
         end
       end
     end

--- a/spec/models/federal_register_client_spec.rb
+++ b/spec/models/federal_register_client_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe FederalRegisterClient, type: :model do
           expect{ client.find_sorns }.to change{ Agency.count }.by 2
 
           expect(Sorn.last.agencies.first).to have_attributes(name: "Department Of Defense", api_id: 103, parent_api_id: nil)
-          expect(Sorn.last.agencies.second).to have_attributes(name: "Office of the Secretary", api_id: 9999, parent_api_id: 103)
+          expect(Sorn.last.agencies.second).to have_attributes(name: "Office of the Secretary, DoD", api_id: 9999, parent_api_id: 103)
         end
       end
     end

--- a/spec/models/federal_register_client_spec.rb
+++ b/spec/models/federal_register_client_spec.rb
@@ -117,11 +117,10 @@ RSpec.describe FederalRegisterClient, type: :model do
           allow(FederalRegister::Document).to receive(:search).and_return result_set
         end
 
-        it "correctly saves the office of the secretary as a subcomponent of the DoD" do
-          expect{ client.find_sorns }.to change{ Agency.count }.by 2
+        it "don't save subcomponents without metadata" do
+          expect{ client.find_sorns }.to change{ Agency.count }.by 1
 
           expect(Sorn.last.agencies.first).to have_attributes(name: "Department Of Defense", api_id: 103, parent_api_id: nil)
-          expect(Sorn.last.agencies.second).to have_attributes(name: "Office of the Secretary, DoD", api_id: 9999, parent_api_id: 103)
         end
       end
     end

--- a/spec/models/federal_register_client_spec.rb
+++ b/spec/models/federal_register_client_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe FederalRegisterClient, type: :model do
       publication_date: "2000-01-13",
       agencies: [
         OpenStruct.new(
-          "raw_name": "FAKE PARENT AGENCY",
+          "raw_name": "PARENT AGENCY",
           "name": "Fake Parent Agency",
           "id": 1,
           "parent_id": nil
         ),
         OpenStruct.new(
-          "raw_name": "FAKE CHILD AGENCY",
+          "raw_name": "CHILD AGENCY",
           "name": "Fake Child Agency",
           "id": 2,
           "parent_id": 1
@@ -55,16 +55,16 @@ RSpec.describe FederalRegisterClient, type: :model do
       it "Creates agencies for each result" do
         expect{ client.find_sorns }.to change{ Agency.count }.by 2
 
-        expect(Sorn.last.agencies.second).to have_attributes(name: "Fake Parent Agency", api_id: 1, parent_api_id: nil)
-        expect(Sorn.last.agencies.first).to have_attributes(name: "Fake Child Agency", api_id: 2, parent_api_id: 1)
+        expect(Sorn.last.agencies.second).to have_attributes(name: "Parent Agency", api_id: 1, parent_api_id: nil)
+        expect(Sorn.last.agencies.first).to have_attributes(name: "Child Agency", api_id: 2, parent_api_id: 1)
       end
 
       context "with existing agencies" do
         let(:sorn) { create :sorn, agencies: [] }
 
         before do
-          sorn.agencies << Agency.create(name: "Fake Parent Agency", api_id: 1, parent_api_id: nil)
-          sorn.agencies << Agency.create(name: "Fake Child Agency", api_id: 2, parent_api_id: 1)
+          sorn.agencies << Agency.create(name: "Parent Agency", api_id: 1, parent_api_id: nil)
+          sorn.agencies << Agency.create(name: "Child Agency", api_id: 2, parent_api_id: 1)
         end
 
         it "Doesn't duplicate agencies" do
@@ -102,7 +102,7 @@ RSpec.describe FederalRegisterClient, type: :model do
             publication_date: "2000-01-13",
             agencies: [
               OpenStruct.new(
-                "raw_name": "DEFENSE DEPARTMENT",
+                "raw_name": "DEPARTMENT OF DEFENSE",
                 "name": "Defense Department",
                 "id": 103,
                 "parent_id": nil
@@ -120,7 +120,7 @@ RSpec.describe FederalRegisterClient, type: :model do
         it "correctly saves the office of the secretary as a subcomponent of the DoD" do
           expect{ client.find_sorns }.to change{ Agency.count }.by 2
 
-          expect(Sorn.last.agencies.first).to have_attributes(name: "Defense Department", api_id: 103, parent_api_id: nil)
+          expect(Sorn.last.agencies.first).to have_attributes(name: "Department Of Defense", api_id: 103, parent_api_id: nil)
           expect(Sorn.last.agencies.second).to have_attributes(name: "Office of the Secretary", api_id: 9999, parent_api_id: 103)
         end
       end

--- a/spec/requests/search_csv_request_spec.rb
+++ b/spec/requests/search_csv_request_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Search csv", type: :request do
   context "with agency search" do
     let(:search) { nil }
     let(:fields) { "fields%5B%5D=agency_names&fields%5B%5D=action&fields%5B%5D=system_name&fields%5B%5D=summary&fields%5B%5D=html_url&fields%5B%5D=publication_date" }
-    let(:agency) { "agencies[]=Fake+Parent+Agency&agencies[]=Fake+Child+Agency" }
+    let(:agency) { "agencies[]=Parent+Agency&agencies[]=Child+Agency" }
 
     it "returns sorns filtered by agency, no duplicates" do
       expect(response.body).to eq "agency_names,action,system_name,summary,html_url,publication_date\nFake Parent Agency | Fake Child Agency,FAKE ACTION,FAKE SYSTEM NAME,FAKE SUMMARY,HTML URL,2000-01-13\n"

--- a/spec/requests/search_csv_request_spec.rb
+++ b/spec/requests/search_csv_request_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Search csv", type: :request do
     let(:agency) { nil }
 
     it "returns eveything with the default columns" do
-      expect(response.body).to eq "agency_names,action,system_name,summary,categories_of_individuals,categories_of_record,html_url,publication_date\nFake Parent Agency | Fake Child Agency,FAKE ACTION,FAKE SYSTEM NAME,FAKE SUMMARY,,,HTML URL,2000-01-13\n"
+      expect(response.body).to eq "agency_names,action,system_name,summary,categories_of_individuals,categories_of_record,html_url,publication_date\nParent Agency | Child Agency,FAKE ACTION,FAKE SYSTEM NAME,FAKE SUMMARY,,,HTML URL,2000-01-13\n"
     end
   end
 
@@ -21,7 +21,7 @@ RSpec.describe "Search csv", type: :request do
     let(:agency) { nil }
 
     it "returns found results with default columns" do
-      expect(response.body).to eq "agency_names,action,system_name,summary,html_url,publication_date\nFake Parent Agency | Fake Child Agency,FAKE ACTION,FAKE SYSTEM NAME,FAKE SUMMARY,HTML URL,2000-01-13\n"
+      expect(response.body).to eq "agency_names,action,system_name,summary,html_url,publication_date\nParent Agency | Child Agency,FAKE ACTION,FAKE SYSTEM NAME,FAKE SUMMARY,HTML URL,2000-01-13\n"
     end
   end
 
@@ -51,7 +51,7 @@ RSpec.describe "Search csv", type: :request do
     let(:agency) { "agencies[]=Parent+Agency&agencies[]=Child+Agency" }
 
     it "returns sorns filtered by agency, no duplicates" do
-      expect(response.body).to eq "agency_names,action,system_name,summary,html_url,publication_date\nFake Parent Agency | Fake Child Agency,FAKE ACTION,FAKE SYSTEM NAME,FAKE SUMMARY,HTML URL,2000-01-13\n"
+      expect(response.body).to eq "agency_names,action,system_name,summary,html_url,publication_date\nParent Agency | Child Agency,FAKE ACTION,FAKE SYSTEM NAME,FAKE SUMMARY,HTML URL,2000-01-13\n"
     end
   end
 end

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe "Search", type: :request do
     end
 
     it "search works with all params" do
-      get "/search?search=different&fields[]=citation&agencies[]=Fake+Parent+Agency&starting_year=2019&ending_year=2020"
+      get "/search?search=different&fields[]=citation&agencies[]=Parent+Agency&starting_year=2019&ending_year=2020"
 
       expect(response.body).to include "NEW SORN" # Newer sorn date
       expect(response.body).to include "2019-01-13" # Newer sorn date

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe "Search", type: :request do
   context "search with agency select" do
     let(:search) { "FAKE" }
     let(:fields) { 'fields[]=action' }
-    let(:agency) { "agencies[]=Fake+Parent+Agency" }
+    let(:agency) { "agencies[]=Parent+Agency" }
 
     it "succeeds" do
       expect(response.successful?).to be_truthy
     end
 
     it "default agency set" do
-      expect(response.body).to include 'data-agencies="[&quot;fake-parent-agency&quot;]"'
+      expect(response.body).to include 'data-agencies="[&quot;parent-agency&quot;]"'
     end
 
     it "with search result summaries" do
@@ -49,8 +49,8 @@ RSpec.describe "Search", type: :request do
 
     context "agency search with overlapping SORNs" do
       let(:fields) { 'fields[]=system_name' }
-      let(:agency) { "agencies[]=Fake+Parent+Agency&agencies[]=Fake+Child+Agency" }
-      let(:child_agency) { create(:agency, name: "Fake Child Agency")}
+      let(:agency) { "agencies[]=Parent+Agency&agencies[]=Child+Agency" }
+      let(:child_agency) { create(:agency, name: "Child Agency")}
 
       before { sorn.agencies << child_agency }
 

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -94,15 +94,13 @@ RSpec.describe "Search", type: :request do
     it "returns found results with default columns" do
       # default fields
       expect(response.body).to include "FAKE SYSTEM NAME"
-      expect(response.body).to include 'Fake Parent Agency'
+      expect(response.body).to include 'Parent Agency | Child Agency'
       expect(response.body).to include "HTML URL"
       expect(response.body).to include "2000-01-13"
     end
 
     it "with search result summaries" do
       expect(response.body).to include 'FOUND IN'
-      expect(response.body).to include "<div class='sorn-attribute-header'>Agency names</div>"
-      expect(response.body).to include "<div class='found-section-snippet'><mark>Fake</mark> Parent Agency | <mark>Fake</mark> Child Agency</div>"
       expect(response.body).to include "<div class='sorn-attribute-header'>Action</div>"
       expect(response.body).to include "<div class='found-section-snippet'><mark>FAKE</mark> ACTION</div>"
       expect(response.body).to include "<div class='sorn-attribute-header'>Summary</div>"

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe "/search", type: :system do
   end
 
   it "selected agencies are still checked after a search" do
-    visit "/search?agencies[]=Fake+Parent+Agency&fields[]=system_name"
-    expect(find("#agencies-fake-parent-agency")).to be_checked
+    visit "/search?agencies[]=Parent+Agency&fields[]=system_name"
+    expect(find("#agencies-parent-agency")).to be_checked
   end
 
   it "applies the wanted class to the agency pipe separator" do


### PR DESCRIPTION
Uses `raw_name` instead of the `name` for Agencies pulled from the Federal Register API. This is a better choice for most agencies, as the `raw_name` more closely matches the common name. 

<img width="278" alt="Screen Shot 2020-12-23 at 11 57 16 AM" src="https://user-images.githubusercontent.com/595778/103032930-16db4d00-4516-11eb-87b1-fe647ef0b939.png">


There are a few that don't match that, such as Bureau of Consumer Financial Protection, but on the whole `raw_name` is a better choice. I don't want to include a lot of custom code, I want to match what the API gives us, for maintainability.

This PR also, drops support for subcomponents without metadata in the API. We were trying to include the DoD's Office of the Secretary, yet there are a dozen or so Office of the Secretary's across agencies. The code to include was getting brittle and would break on any changes to those subcomponents in the API. A user can still search for "Secretary" against the "Agency Names" field, with the DoD selected, and get that same list.

### Deploy
- If approved, please don't squash this one. We may want [this commit](https://github.com/18F/all_sorns/pull/95/commits/9c524d54f189d3de4a33a7c894862695abbcc693) for later.
- Delete all the Agencies and repopulate them.
```
rails console
Agency.destroy_all
exit
rails federal_register:find_sorns
```

Closes #88 