### PR TITLE
Increase app memory to 1G

### DIFF
--- a/.cloud-gov/manifest-dev.yml
+++ b/.cloud-gov/manifest-dev.yml
@@ -3,7 +3,7 @@
   - name: all_sorns_dev
     buildpacks:
       - ruby_buildpack
-    memory: 512MB
+    memory: 1G
     services:
       - all-sorns-db-dev
     command: bundle exec rake cf:on_first_instance db:migrate && bundle exec rails s -p $PORT -e $RAILS_ENV

--- a/.cloud-gov/manifest.yml
+++ b/.cloud-gov/manifest.yml
@@ -3,7 +3,7 @@
   - name: all_sorns
     buildpacks:
       - ruby_buildpack
-    memory: 512MB
+    memory: 1G
     services:
       - all-sorns-db
     command: ./.cloud-gov/start.sh


### PR DESCRIPTION
The default is 1G. We had it lower for our earlier sandbox account.