### PR TITLE
paginate array only for multi-word searches

### DIFF
--- a/app/controllers/sorns_controller.rb
+++ b/app/controllers/sorns_controller.rb
@@ -52,9 +52,12 @@ class SornsController < ApplicationController
       @sorns = @sorns.where('publication_date::DATE < ?', ending_date)
     end
 
-    @sorns = @sorns.only_exact_matches(params[:search], @selected_fields) if multiword_search?
-
-    @sorns = Kaminari.paginate_array(@sorns).page(params[:page]) if request.format == :html
+    if multiword_search?
+      @sorns = @sorns.only_exact_matches(params[:search], @selected_fields)
+      @sorns = Kaminari.paginate_array(@sorns).page(params[:page]) if request.format == :html
+    else
+      @sorns = @sorns.page(params[:page]) if request.format == :html
+    end
 
     respond_to do |format|
       format.html


### PR DESCRIPTION
For our multi-word search approach, we are doing another loop over the postgres full-text search results, to only include exact matches. This turns our `@sorns` Active Record Association into an array. Preparing the pagination of an array is slower and more memory intensive.

This PR changes it so we only paginate from an array if we are doing a multi-word search. These searches are usually for a smaller number of sorns, so our app can handle them. It was crashing from memory outtages when we were paginating the array of a new page load with all of our sorns.

This also gets our regular searches back to the speed they were usually at.

With this PR, a request to localhost:3000 is 10 times faster and a tenth of the memory allocations.
`Completed 200 OK in 563ms (Views: 343.1ms | ActiveRecord: 198.0ms | Allocations: 124526)`
before
`Completed 200 OK in 4124ms (Views: 33.1ms | ActiveRecord: 2101.2ms | Allocations: 1475778)`

