### PR TITLE
Get agencies' short_name

### DIFF
--- a/app/jobs/find_sorns_job.rb
+++ b/app/jobs/find_sorns_job.rb
@@ -2,6 +2,10 @@ class FindSornsJob < ApplicationJob
   queue_as :default
 
   def perform(*args)
-    FederalRegisterClient.new.find_sorns
+    begin
+      FederalRegisterClient.new.find_sorns
+    rescue => e
+      p e.exception
+    end
   end
 end

--- a/app/models/federal_register_client.rb
+++ b/app/models/federal_register_client.rb
@@ -124,6 +124,7 @@ class FederalRegisterClient
         )
       elsif agency.short_name.nil? # Can remove after everyone has short_name locally
         agency.update(short_name: get_agency_short_name(api_agency.id))
+        return agency
       end
     end
   end

--- a/app/models/federal_register_client.rb
+++ b/app/models/federal_register_client.rb
@@ -88,7 +88,6 @@ class FederalRegisterClient
 
   def add_agencies(result, sorn)
     # add agency to sorn, without duplicates
-    # special case for DoD Office of the Secretary
     result.agencies.each do |api_agency|
       agency = build_agency(result, api_agency)
       if agency.present? && sorn.agencies.exclude?(agency)

--- a/db/migrate/20201228232801_add_short_name_to_agency.rb
+++ b/db/migrate/20201228232801_add_short_name_to_agency.rb
@@ -1,0 +1,5 @@
+class AddShortNameToAgency < ActiveRecord::Migration[6.0]
+  def change
+    add_column :agencies, :short_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_13_200542) do
+ActiveRecord::Schema.define(version: 2020_12_28_232801) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2020_11_13_200542) do
     t.integer "parent_api_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "short_name"
     t.index ["api_id"], name: "index_agencies_on_api_id"
     t.index ["parent_api_id"], name: "index_agencies_on_parent_api_id"
   end
@@ -33,7 +34,7 @@ ActiveRecord::Schema.define(version: 2020_11_13_200542) do
     t.index ["sorn_id"], name: "index_agencies_sorns_on_sorn_id"
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"
@@ -98,6 +99,7 @@ ActiveRecord::Schema.define(version: 2020_11_13_200542) do
     t.index "to_tsvector('english'::regconfig, (access)::text)", name: "access_idx", using: :gist
     t.index "to_tsvector('english'::regconfig, (action)::text)", name: "action_idx", using: :gist
     t.index "to_tsvector('english'::regconfig, (addresses)::text)", name: "addresses_idx", using: :gist
+    t.index "to_tsvector('english'::regconfig, (agency_names)::text)", name: "agency_names_idx", using: :gist
     t.index "to_tsvector('english'::regconfig, (authority)::text)", name: "authority_idx", using: :gist
     t.index "to_tsvector('english'::regconfig, (categories_of_individuals)::text)", name: "categories_of_individuals_idx", using: :gist
     t.index "to_tsvector('english'::regconfig, (categories_of_record)::text)", name: "categories_of_record_idx", using: :gist


### PR DESCRIPTION
This PR will get every agencies' short_name the next time the `find_sorns` task is run. Closes #90 

Acceptance will have to be done when pairing, to show you that the short_name is in the db.