### PR TITLE
WIP Materialized view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'federal_register', '~> 0.7.6'
 gem 'saxerator'
 gem 'pg_search'
 gem 'kaminari'
+gem 'scenic'
 
 # Use Puma as the app server
 gem 'puma', '~> 4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,9 @@ GEM
       sprockets-rails
       tilt
     saxerator (0.9.9)
+    scenic (1.5.4)
+      activerecord (>= 4.0.0)
+      railties (>= 4.0.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -295,6 +298,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.1)
   sass-rails (>= 6)
   saxerator
+  scenic
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/sorns_controller.rb
+++ b/app/controllers/sorns_controller.rb
@@ -34,8 +34,7 @@ class SornsController < ApplicationController
       @selected_agencies = params[:agencies].map(&:parameterize)
       field_syms = @selected_fields.map { |field| field.to_sym }
       @sorns = @sorns.joins(:agencies).where(agencies: {name: params[:agencies]})
-      @sorns = @sorns.dynamic_search(field_syms, params[:search])
-      @sorns = @sorns.get_distinct_with_dynamic_search
+      @sorns = @sorns.where(id: SornSearch.search(params[:search]).select(:sorn_id))
     else
       raise "WUT"
     end

--- a/app/models/sorn_search.rb
+++ b/app/models/sorn_search.rb
@@ -1,0 +1,15 @@
+class SornSearch < ApplicationRecord
+  self.primary_key = :sorn_id
+
+  include PgSearch::Model
+  pg_search_scope(
+    :search,
+    against: :tsv_document,
+    using: {
+      tsearch: {
+        dictionary: 'english',
+        tsvector_column: 'tsv_document',
+      },
+    },
+  )
+end

--- a/db/migrate/20201230230531_create_sorn_searches.rb
+++ b/db/migrate/20201230230531_create_sorn_searches.rb
@@ -1,0 +1,7 @@
+class CreateSornSearches < ActiveRecord::Migration[6.0]
+  def change
+    create_view :sorn_searches, materialized: true
+
+    add_index :sorn_searches, :tsv_document, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_28_232801) do
+ActiveRecord::Schema.define(version: 2020_12_30_230531) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 2020_12_28_232801) do
     t.index ["sorn_id"], name: "index_agencies_sorns_on_sorn_id"
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"
@@ -125,5 +125,13 @@ ActiveRecord::Schema.define(version: 2020_12_28_232801) do
     t.index "to_tsvector('english'::regconfig, (system_number)::text)", name: "system_number_idx", using: :gist
     t.index ["citation"], name: "index_sorns_on_citation"
   end
+
+
+  create_view "sorn_searches", materialized: true, sql_definition: <<-SQL
+      SELECT sorns.id AS sorn_id,
+      ((((((((((((((((((((((((((to_tsvector('english'::regconfig, (COALESCE(sorns.agency_names, ''::character varying))::text) || to_tsvector('english'::regconfig, (COALESCE(sorns.action, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.summary, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.dates, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.addresses, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.further_info, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.supplementary_info, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.system_name, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.system_number, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.security, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.location, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.manager, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.authority, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.purpose, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.categories_of_individuals, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.categories_of_record, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.source, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.routine_uses, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.storage, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.retrieval, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.retention, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.safeguards, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.access, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.contesting, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.notification, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.exemptions, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.history, ''::character varying))::text)) AS tsv_document
+     FROM sorns;
+  SQL
+  add_index "sorn_searches", ["tsv_document"], name: "index_sorn_searches_on_tsv_document", using: :gin
 
 end

--- a/db/views/sorn_searches_v01.sql
+++ b/db/views/sorn_searches_v01.sql
@@ -1,0 +1,32 @@
+SELECT
+  sorns.id AS sorn_id,
+  (
+    to_tsvector('english', coalesce(sorns.agency_names, ''))
+    || to_tsvector('english', coalesce(sorns.action, ''))
+    || to_tsvector('english', coalesce(sorns.summary, ''))
+    || to_tsvector('english', coalesce(sorns.dates, ''))
+    || to_tsvector('english', coalesce(sorns.addresses, ''))
+    || to_tsvector('english', coalesce(sorns.further_info, ''))
+    || to_tsvector('english', coalesce(sorns.supplementary_info, ''))
+    || to_tsvector('english', coalesce(sorns.system_name, ''))
+    || to_tsvector('english', coalesce(sorns.system_number, ''))
+    || to_tsvector('english', coalesce(sorns.security, ''))
+    || to_tsvector('english', coalesce(sorns.location, ''))
+    || to_tsvector('english', coalesce(sorns.manager, ''))
+    || to_tsvector('english', coalesce(sorns.authority, ''))
+    || to_tsvector('english', coalesce(sorns.purpose, ''))
+    || to_tsvector('english', coalesce(sorns.categories_of_individuals, ''))
+    || to_tsvector('english', coalesce(sorns.categories_of_record, ''))
+    || to_tsvector('english', coalesce(sorns.source, ''))
+    || to_tsvector('english', coalesce(sorns.routine_uses, ''))
+    || to_tsvector('english', coalesce(sorns.storage, ''))
+    || to_tsvector('english', coalesce(sorns.retrieval, ''))
+    || to_tsvector('english', coalesce(sorns.retention, ''))
+    || to_tsvector('english', coalesce(sorns.safeguards, ''))
+    || to_tsvector('english', coalesce(sorns.access, ''))
+    || to_tsvector('english', coalesce(sorns.contesting, ''))
+    || to_tsvector('english', coalesce(sorns.notification, ''))
+    || to_tsvector('english', coalesce(sorns.exemptions, ''))
+    || to_tsvector('english', coalesce(sorns.history, ''))
+  ) AS tsv_document
+FROM sorns;


### PR DESCRIPTION
This PR is an experiment in database tuning. It adds:
- single materialized view with tsvectors for all columns at once.
- an indexes for this view
It will need some new code if people want to search for certain columns, not everything.

#### Results
For single word searches its about three times faster.
For multi word searches, its one second faster.


http://localhost:3000/ with 5890 SORNs -
1. blank search  `Completed 200 OK in 126ms (Views: 62.3ms | ActiveRecord: 63.0ms | Allocations: 35705)`
2. search for ssn `Completed 200 OK in 234ms (Views: 96.6ms | ActiveRecord: 119.2ms | Allocations: 77922)`
3. multiword search for social security number `Completed 200 OK in 3081ms (Views: 50.5ms | ActiveRecord: 1619.7ms | Allocations: 1081335)`

**main branch results**
1. blank search - `Completed 200 OK in 123ms (Views: 57.9ms | ActiveRecord: 64.3ms | Allocations: 35703)`
2. search for ssn `Completed 200 OK in 2907ms (Views: 82.8ms | ActiveRecord: 2813.2ms | Allocations: 76911)`
3. multiword search social security number `Completed 200 OK in 3632ms (Views: 121.9ms | ActiveRecord: 2464.4ms | Allocations: 685153)`