### PR TITLE
Research - ilike search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'federal_register', '~> 0.7.6'
 gem 'saxerator'
 gem 'pg_search'
 gem 'kaminari'
+gem 'scenic'
 
 # Use Puma as the app server
 gem 'puma', '~> 4.1'

--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,7 @@ gem 'pg'
 gem 'httparty'
 gem 'federal_register', '~> 0.7.6'
 gem 'saxerator'
-gem 'pg_search'
 gem 'kaminari'
-gem 'scenic'
 
 # Use Puma as the app server
 gem 'puma', '~> 4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,9 @@ GEM
       sprockets-rails
       tilt
     saxerator (0.9.9)
+    scenic (1.5.4)
+      activerecord (>= 4.0.0)
+      railties (>= 4.0.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -295,6 +298,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.1)
   sass-rails (>= 6)
   saxerator
+  scenic
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,9 +145,6 @@ GEM
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     pg (1.2.3)
-    pg_search (2.3.4)
-      activerecord (>= 5.2)
-      activesupport (>= 5.2)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -228,9 +225,6 @@ GEM
       sprockets-rails
       tilt
     saxerator (0.9.9)
-    scenic (1.5.4)
-      activerecord (>= 4.0.0)
-      railties (>= 4.0.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -289,7 +283,6 @@ DEPENDENCIES
   launchy
   listen (~> 3.2)
   pg
-  pg_search
   pry-byebug
   pry-rescue
   pry-stack_explorer
@@ -298,7 +291,6 @@ DEPENDENCIES
   rspec-rails (~> 4.0.1)
   sass-rails (>= 6)
   saxerator
-  scenic
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -195,13 +195,6 @@
  }
 
 
-
- #sorn-fields {
-  overflow-y: scroll;
-  height: 312px;
-  border-bottom: 1px solid #C4C4C4;
- }
-
  #agency-select-label {
    margin-top: 0;
  }

--- a/app/controllers/sorns_controller.rb
+++ b/app/controllers/sorns_controller.rb
@@ -34,8 +34,7 @@ class SornsController < ApplicationController
       @selected_agencies = params[:agencies].map(&:parameterize)
       field_syms = @selected_fields.map { |field| field.to_sym }
       @sorns = @sorns.joins(:agencies).where(agencies: {name: params[:agencies]})
-      @sorns = @sorns.dynamic_search(field_syms, params[:search])
-      @sorns = @sorns.get_distinct_with_dynamic_search
+      @sorns = @sorns.where(id: SornSearch.search(params[:search]).select(:sorn_id))
     else
       raise "WUT"
     end

--- a/app/javascript/packs/search.js
+++ b/app/javascript/packs/search.js
@@ -1,4 +1,6 @@
 $( function () {
+  hideEmptyFormFieldsFromUrl()
+
   // Set checked fields from url
   checkboxesFromUrl("fields")
 
@@ -47,4 +49,15 @@ function publicationDateValidation(){
   } else {
     $("#starting_year")[0].setCustomValidity('');
   }
+}
+
+function hideEmptyFormFieldsFromUrl(){
+  // Change 'form' to class or ID of your specific form
+  $("#search-form").on("submit", function() {
+    $(this).find(":input").filter(function(){ return !this.value; }).attr("disabled", "disabled");
+    return true; // ensure form still submits
+  });
+
+  // Un-disable form fields when page loads, in case they click back after submission
+  $( "#search-form" ).find( ":input" ).prop( "disabled", false );
 }

--- a/app/models/sorn.rb
+++ b/app/models/sorn.rb
@@ -5,12 +5,11 @@ class Sorn < ApplicationRecord
   has_and_belongs_to_many :mentioned, class_name: "Sorn", join_table: :mentions,
                           foreign_key: :sorn_id, association_foreign_key: :mentioned_sorn_id
 
-  include PgSearch::Model
   validates :citation, uniqueness: true
 
   scope :no_computer_matching, -> { where.not('"sorns"."action" ILIKE ?', '%matching%') }
   scope :get_distinct, -> { select(:id, Sorn::FIELDS + Sorn::METADATA).distinct }
-  scope :get_distinct_with_dynamic_search, -> { select(:id, Sorn::FIELDS + Sorn::METADATA,"#{PgSearch::Configuration.alias('sorns')}.rank").distinct }
+  # scope :get_distinct_with_dynamic_search, -> { select(:id, Sorn::FIELDS + Sorn::METADATA,"#{PgSearch::Configuration.alias('sorns')}.rank").distinct }
 
   default_scope { order(publication_date: :desc) }
 
@@ -64,13 +63,6 @@ class Sorn < ApplicationRecord
     'html_url',
     'publication_date'
   ]
-
-  pg_search_scope :dynamic_search, lambda { |field, query|
-    {
-      against: field,
-      query: query
-    }
-  }
 
   def get_xml
     if xml_url.present? and xml.blank?

--- a/app/models/sorn_search.rb
+++ b/app/models/sorn_search.rb
@@ -1,0 +1,15 @@
+class SornSearch < ApplicationRecord
+  self.primary_key = :sorn_id
+
+  include PgSearch::Model
+  pg_search_scope(
+    :search,
+    against: :tsv_document,
+    using: {
+      tsearch: {
+        dictionary: 'english',
+        tsvector_column: 'tsv_document',
+      },
+    },
+  )
+end

--- a/app/views/sorns/_agencies.html.erb
+++ b/app/views/sorns/_agencies.html.erb
@@ -5,7 +5,7 @@
   <div id="selected-agencies" class="list">
     <% Agency.all.each do |agency| %>
       <div class="usa-checkbox">
-        <input class="usa-checkbox__input" id="agencies-<%= agency.name&.parameterize %>" type="checkbox" name="agencies[]" value="<%= agency.name %>" checked>
+        <input class="usa-checkbox__input" id="agencies-<%= agency.name&.parameterize %>" type="checkbox" name="agencies[]" value="<%= agency.name %>">
         <label class="usa-checkbox__label agency-name" for="agencies-<%= agency.name&.parameterize %>"><%= agency.name %></label>
       </div>
     <% end %>

--- a/app/views/sorns/_fields.html.erb
+++ b/app/views/sorns/_fields.html.erb
@@ -1,11 +1,6 @@
 <fieldset id="fields" class="usa-fieldset margin-105">
-  <legend class="usa-legend">
-    <div id="search-filters">Search filters</div>
-    <div id="fields-to-search">Fields to search</div>
-  </legend>
-
   <div id="sorn-fields">
-    <% checkboxes = Sorn::FIELDS + Sorn::METADATA %>
+    <% checkboxes = Sorn::FIELDS %>
     <% checkboxes.each do |field, index| %>
       <div class="usa-checkbox">
         <input class="usa-checkbox__input" id="fields-<%= field %>" type="checkbox" name="fields[]" value="<%= field %>">

--- a/app/views/sorns/search.html.erb
+++ b/app/views/sorns/search.html.erb
@@ -7,7 +7,7 @@
   </div>
 </header>
 
-<%= form_tag '/search', method: "GET", id: "search-form" do %>
+<%= form_tag '/', method: "GET", id: "search-form" do %>
 <section class="grid-container">
   <div class="grid-col-10 grid-offset-1 search-area">
     <h2>Search for SORNs by entering a keyword (will return exact matches)</h2>
@@ -26,9 +26,13 @@
         <div class="border border-gray-70 sidebar">
           <div class="preview usa-prose site-prose" >
 
-            <%= render partial: "fields" %>
-
             <div class="usa-accordion">
+              <h2 class="usa-accordion__heading">
+                <button class="usa-accordion__button" aria-controls="sorn-sections-accordion" type="button">SORN Sections</button>
+              </h2>
+              <div id="sorn-sections-accordion" class="usa-accordion__content usa-prose">
+                <%= render partial: "fields" %>
+              </div>
               <h2 class="usa-accordion__heading">
                 <button class="usa-accordion__button" aria-controls="agency-accordion" type="button">Agencies</button>
               </h2>

--- a/db/migrate/20201230230531_create_sorn_searches.rb
+++ b/db/migrate/20201230230531_create_sorn_searches.rb
@@ -1,7 +1,0 @@
-class CreateSornSearches < ActiveRecord::Migration[6.0]
-  def change
-    create_view :sorn_searches, materialized: true
-
-    add_index :sorn_searches, :tsv_document, using: :gin
-  end
-end

--- a/db/migrate/20201230230531_create_sorn_searches.rb
+++ b/db/migrate/20201230230531_create_sorn_searches.rb
@@ -1,0 +1,7 @@
+class CreateSornSearches < ActiveRecord::Migration[6.0]
+  def change
+    create_view :sorn_searches, materialized: true
+
+    add_index :sorn_searches, :tsv_document, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_30_230531) do
+ActiveRecord::Schema.define(version: 2020_12_28_232801) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -98,13 +98,5 @@ ActiveRecord::Schema.define(version: 2020_12_30_230531) do
     t.string "action_type"
     t.index ["citation"], name: "index_sorns_on_citation"
   end
-
-
-  create_view "sorn_searches", materialized: true, sql_definition: <<-SQL
-      SELECT sorns.id AS sorn_id,
-      ((((((((((((((((((((((((((to_tsvector('english'::regconfig, (COALESCE(sorns.agency_names, ''::character varying))::text) || to_tsvector('english'::regconfig, (COALESCE(sorns.action, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.summary, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.dates, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.addresses, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.further_info, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.supplementary_info, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.system_name, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.system_number, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.security, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.location, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.manager, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.authority, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.purpose, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.categories_of_individuals, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.categories_of_record, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.source, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.routine_uses, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.storage, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.retrieval, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.retention, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.safeguards, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.access, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.contesting, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.notification, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.exemptions, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.history, ''::character varying))::text)) AS tsv_document
-     FROM sorns;
-  SQL
-  add_index "sorn_searches", ["tsv_document"], name: "index_sorn_searches_on_tsv_document", using: :gin
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_28_232801) do
+ActiveRecord::Schema.define(version: 2020_12_30_230531) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 2020_12_28_232801) do
     t.index ["sorn_id"], name: "index_agencies_sorns_on_sorn_id"
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"
@@ -125,5 +125,13 @@ ActiveRecord::Schema.define(version: 2020_12_28_232801) do
     t.index "to_tsvector('english'::regconfig, (system_number)::text)", name: "system_number_idx", using: :gist
     t.index ["citation"], name: "index_sorns_on_citation"
   end
+
+
+  create_view "sorn_searches", materialized: true, sql_definition: <<-SQL
+      SELECT sorns.id AS sorn_id,
+      ((((((((((((((((((((((((((to_tsvector('english'::regconfig, (COALESCE(sorns.agency_names, ''::character varying))::text) || to_tsvector('english'::regconfig, (COALESCE(sorns.action, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.summary, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.dates, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.addresses, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.further_info, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.supplementary_info, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.system_name, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.system_number, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.security, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.location, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.manager, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.authority, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.purpose, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.categories_of_individuals, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.categories_of_record, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.source, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.routine_uses, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.storage, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.retrieval, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.retention, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.safeguards, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.access, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.contesting, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.notification, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.exemptions, ''::character varying))::text)) || to_tsvector('english'::regconfig, (COALESCE(sorns.history, ''::character varying))::text)) AS tsv_document
+     FROM sorns;
+  SQL
+  add_index "sorn_searches", ["tsv_document"], name: "index_sorn_searches_on_tsv_document", using: :gin
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -96,33 +96,6 @@ ActiveRecord::Schema.define(version: 2020_12_30_230531) do
     t.string "publication_date"
     t.string "title"
     t.string "action_type"
-    t.index "to_tsvector('english'::regconfig, (access)::text)", name: "access_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (action)::text)", name: "action_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (addresses)::text)", name: "addresses_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (agency_names)::text)", name: "agency_names_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (authority)::text)", name: "authority_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (categories_of_individuals)::text)", name: "categories_of_individuals_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (categories_of_record)::text)", name: "categories_of_record_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (contesting)::text)", name: "contesting_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (dates)::text)", name: "dates_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (exemptions)::text)", name: "exemptions_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (further_info)::text)", name: "further_info_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (history)::text)", name: "history_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (location)::text)", name: "location_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (manager)::text)", name: "manager_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (notification)::text)", name: "notification_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (purpose)::text)", name: "purpose_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (retention)::text)", name: "retention_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (retrieval)::text)", name: "retrieval_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (routine_uses)::text)", name: "routine_uses_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (safeguards)::text)", name: "safeguards_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (security)::text)", name: "security_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (source)::text)", name: "source_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (storage)::text)", name: "storage_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (summary)::text)", name: "summary_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (supplementary_info)::text)", name: "supplementary_info_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (system_name)::text)", name: "system_name_idx", using: :gist
-    t.index "to_tsvector('english'::regconfig, (system_number)::text)", name: "system_number_idx", using: :gist
     t.index ["citation"], name: "index_sorns_on_citation"
   end
 

--- a/db/views/sorn_searches_v01.sql
+++ b/db/views/sorn_searches_v01.sql
@@ -1,0 +1,32 @@
+SELECT
+  sorns.id AS sorn_id,
+  (
+    to_tsvector('english', coalesce(sorns.agency_names, ''))
+    || to_tsvector('english', coalesce(sorns.action, ''))
+    || to_tsvector('english', coalesce(sorns.summary, ''))
+    || to_tsvector('english', coalesce(sorns.dates, ''))
+    || to_tsvector('english', coalesce(sorns.addresses, ''))
+    || to_tsvector('english', coalesce(sorns.further_info, ''))
+    || to_tsvector('english', coalesce(sorns.supplementary_info, ''))
+    || to_tsvector('english', coalesce(sorns.system_name, ''))
+    || to_tsvector('english', coalesce(sorns.system_number, ''))
+    || to_tsvector('english', coalesce(sorns.security, ''))
+    || to_tsvector('english', coalesce(sorns.location, ''))
+    || to_tsvector('english', coalesce(sorns.manager, ''))
+    || to_tsvector('english', coalesce(sorns.authority, ''))
+    || to_tsvector('english', coalesce(sorns.purpose, ''))
+    || to_tsvector('english', coalesce(sorns.categories_of_individuals, ''))
+    || to_tsvector('english', coalesce(sorns.categories_of_record, ''))
+    || to_tsvector('english', coalesce(sorns.source, ''))
+    || to_tsvector('english', coalesce(sorns.routine_uses, ''))
+    || to_tsvector('english', coalesce(sorns.storage, ''))
+    || to_tsvector('english', coalesce(sorns.retrieval, ''))
+    || to_tsvector('english', coalesce(sorns.retention, ''))
+    || to_tsvector('english', coalesce(sorns.safeguards, ''))
+    || to_tsvector('english', coalesce(sorns.access, ''))
+    || to_tsvector('english', coalesce(sorns.contesting, ''))
+    || to_tsvector('english', coalesce(sorns.notification, ''))
+    || to_tsvector('english', coalesce(sorns.exemptions, ''))
+    || to_tsvector('english', coalesce(sorns.history, ''))
+  ) AS tsv_document
+FROM sorns;

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -2,18 +2,8 @@ require "rails_helper"
 
 RSpec.describe "/search", type: :system do
   before do
-    driven_by(:selenium_chrome_headless)
+    driven_by(:selenium_chrome)#_headless)
     11.times { create :sorn }
-  end
-
-  it "default checkboxes are as expected" do
-    visit "/search"
-
-    Sorn::DEFAULT_FIELDS.each do |default_field|
-      expect(find("#fields-#{default_field}")).to be_checked
-    end
-
-    expect(find("#fields-routine_uses")).not_to be_checked
   end
 
   it "selected agencies are still checked after a search" do
@@ -22,7 +12,7 @@ RSpec.describe "/search", type: :system do
   end
 
   it "applies the agency-separator class to the agency pipe separator" do
-    visit "/search"
+    visit "/"
 
     expect(page).to have_css '.agency-separator'
   end


### PR DESCRIPTION
This PR searches across all of our SORNs using SQL "ILIKE" which looks for case-insensitive matches of the search term.

Our data has long text columns, which can't be indexed. This PR has really slow searches.

**NOTE->**  We may want to use the idea of searching against the XML column for our full SORN searches in the other branches

#### Results
Searching against all columns ( we just do one search on the xml ),  its 3.5 seconds
Searching against a dynamic set of columns, its 2.5 seconds.
