### PR TITLE
Update beta banner colors

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -43,7 +43,7 @@
 
  // Header & Navigation
  .beta-banner {
-  background-color: $blue-10;
+  background-color: $gold-10v;
   color: $blue-90;
   margin: auto 0;
   padding: 0.1rem 0;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,7 +20,7 @@
  $blue-70:      #005599; //primary blue
  $blue-50:      #006DB6;
  $blue-20:      #CCD6E0;
- $blue-10:      #E0E6EB;
+ $blue-10:      #D9E8F6;
  $blue-10V:     #CFE8FF;
 
  $gray-cool-50: #71767A;
@@ -43,8 +43,8 @@
 
  // Header & Navigation
  .beta-banner {
-  background-color: $blue-90;
-  color: $gray-2;
+  background-color: $blue-10;
+  color: $blue-90;
   margin: auto 0;
   padding: 0.1rem 0;
 


### PR DESCRIPTION
Once we switched over to the updated color scheming, the beta banner created a sort of "color sandwich" for the header/navigation. This is PR changes the beta banner background color to a lighter gold to separate it from the rest of the site and reduce the focus on the header

![image](https://user-images.githubusercontent.com/52677065/103951300-6885f900-510c-11eb-90f8-2ee7a9aa4e61.png)

Open to thoughts on the color