### PR TITLE
Adjust spacing and hover on filters

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -164,6 +164,14 @@
    margin-top: 0;
  }
 
+ .sidebar .usa-accordion__heading:not(:first-child) {
+  margin-top: 0;
+}
+
+ .sidebar .usa-accordion__button:hover {
+   background-color: $gray-5;
+ }
+
  .usa-nav__secondary {
    color: white;
  }


### PR DESCRIPTION
This PR adjusts the spacing between filters, making it more consistent and in doing so also vertically centers the text. Also adds a light grey background color on hover to give a hover indication. 

Current:
![image](https://user-images.githubusercontent.com/52677065/104212743-8b155c00-5403-11eb-8b95-d39ff2a1499c.png)


PR (hover over "Agencies"):
![image](https://user-images.githubusercontent.com/52677065/104212973-cfa0f780-5403-11eb-815c-c0bd0077c0a2.png)
