### PR TITLE
SORN hist reorder

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -365,6 +365,20 @@
    font-weight: bold;
  }
 
+ .sorn-history__list {
+   list-style-position: inside;
+   padding-left: 0;
+ }
+
+ .sorn-history__item:marker {
+   margin: 0 .5em 0 0;
+ }
+
+ .sorn-history__seperator {
+   margin: 0 0.5em;
+   font-weight: bold;
+ }
+
  .found-in {
   width: 100%;
  }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -370,8 +370,8 @@
    padding-left: 0;
  }
 
- .sorn-history__item:marker {
-   margin: 0 .5em 0 0;
+ .sorn-history__content {
+   margin-left: -0.5em;
  }
 
  .sorn-history__seperator {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -43,7 +43,7 @@
   &.pre-search {
     background-image: image-url("PrvOps_SornDash_Landing_02.svg");
     background-repeat: no-repeat;
-    background-position: left bottom;
+    background-position: -3em bottom;
   }
  }
 

--- a/app/views/sorns/search.html.erb
+++ b/app/views/sorns/search.html.erb
@@ -129,11 +129,12 @@
                         <ul class="sorn-history__list">
                         <% sorn.mentioned.each do |metioned_sorn| %>
                           <li class="sorn-history__item">
+                            <span class="sorn-history__content">
                             <a href="<%= metioned_sorn.html_url %>" class="mention-citation"><%= metioned_sorn.citation %></a>:
                             <span class="sorn-history__date"><%= metioned_sorn.publication_date %></span>
                             <span class="sorn-history__seperator">|</span>
                             <span class="sorn-history__action"><%= metioned_sorn.action %></span>
-
+                            </span>
                           </li>
                         <% end %>
                         </ul>

--- a/app/views/sorns/search.html.erb
+++ b/app/views/sorns/search.html.erb
@@ -125,7 +125,7 @@
                   <% if sorn.mentioned.present? %>
                     <div class="grid-row">
                       <div class="grid-col-12">
-                        <span class="sorn-attribute-header">SORN History and/or other SORNS referenced:</span>
+                        <span class="sorn-attribute-header">SORN Versions and/or other SORNs referenced:</span>
                         <ul class="sorn-history__list">
                         <% sorn.mentioned.each do |metioned_sorn| %>
                           <li class="sorn-history__item">

--- a/app/views/sorns/search.html.erb
+++ b/app/views/sorns/search.html.erb
@@ -125,7 +125,7 @@
                   <% if sorn.mentioned.present? %>
                     <div class="grid-row">
                       <div class="grid-col-12">
-                        <span class="sorn-attribute-header">SORN Versions and/or other SORNs referenced:</span>
+                        <span class="sorn-attribute-header">SORN versions and/or other SORNs referenced:</span>
                         <ul class="sorn-history__list">
                         <% sorn.mentioned.each do |metioned_sorn| %>
                           <li class="sorn-history__item">

--- a/app/views/sorns/search.html.erb
+++ b/app/views/sorns/search.html.erb
@@ -126,12 +126,14 @@
                     <div class="grid-row">
                       <div class="grid-col-12">
                         <span class="sorn-attribute-header">SORN History and/or other SORNS referenced:</span>
-                        <ul>
+                        <ul class="sorn-history__list">
                         <% sorn.mentioned.each do |metioned_sorn| %>
-                          <li>
+                          <li class="sorn-history__item">
                             <a href="<%= metioned_sorn.html_url %>" class="mention-citation"><%= metioned_sorn.citation %></a>:
-                            <%= metioned_sorn.action %>,
-                            <%= metioned_sorn.publication_date %>
+                            <span class="sorn-history__date"><%= metioned_sorn.publication_date %></span>
+                            <span class="sorn-history__seperator">|</span>
+                            <span class="sorn-history__action"><%= metioned_sorn.action %></span>
+
                           </li>
                         <% end %>
                         </ul>


### PR DESCRIPTION
This PR reverses the order of the date and action in the SORN History section, and adds a vertical bar between them. The aim is to allow privacy officers to more quickly discover that there are dates included for this SORN history, and more closely align those dates so they can scan through them. 

Another proposed changed in this PR is modifying the language of the label  to "SORN **Versions** and/or other SORNs referenced:"  instead of SORN **history**.  I am wondering if that language, combined with the reordering might make the content of this section clearer

![image](https://user-images.githubusercontent.com/52677065/104516829-f8bbb680-55c2-11eb-87ae-28465ec34283.png)


Also making a small adjustment to the magnifying glass illustration on the landing page to be slightly offset.