### PR TITLE
Fix csv request not filtering on agencies

### DIFF
--- a/app/views/sorns/search.html.erb
+++ b/app/views/sorns/search.html.erb
@@ -36,7 +36,7 @@
           </div>
         </div>
         <div id="csv-download">
-          <%= link_to search_path(search: params[:search], fields: params[:fields], agency: params[:agency], format: :csv).html_safe do %>
+          <%= link_to search_path(search: params[:search], fields: @fields_to_search, agencies: params[:agencies], starting_year: params[:starting_year], ending_year: params[:ending_year], format: :csv) do %>
             <%= image_tag "Download_Icon.svg"%>
             <span class="csv-download-link-text">Download results as a CSV file</span>
           <% end %>

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -134,4 +134,12 @@ RSpec.describe "Search", type: :request do
       expect(response.body).to include "<mark>different</mark>" # Newer citation
     end
   end
+
+  context "csv link" do
+    it "has the right params" do
+      get "/search?search=different&fields[]=citation&agencies[]=Parent+Agency&starting_year=2019&ending_year=2020"
+
+      expect(response.body).to include '<a href="/search.csv?agencies%5B%5D=Parent+Agency&amp;ending_year=2020&amp;fields%5B%5D=citation&amp;search=different&amp;starting_year=2019">'
+    end
+  end
 end


### PR DESCRIPTION
Our csv download had the old parameter names and wasn't filtering on agency or publication date. This PR fixes that.