### PR TITLE
get exact mutliword searches using ilike

### DIFF
--- a/app/controllers/sorns_controller.rb
+++ b/app/controllers/sorns_controller.rb
@@ -56,7 +56,9 @@ class SornsController < ApplicationController
   end
 
   def only_exact_matches
-    @sorns.only_exact_matches(params[:search], @fields_to_search)
+    # postgres is giving us matches where any search word is returned. We want only exact matches.
+    ilikes_sql = @fields_to_search.map{ |field| "#{field} ILIKE :search"}.join(" OR ")
+    @sorns = @sorns.where(ilikes_sql, search: "%#{params[:search]}%")
   end
 
   def is_a_year?(user_entered_date)

--- a/app/models/sorn.rb
+++ b/app/models/sorn.rb
@@ -152,13 +152,6 @@ class Sorn < ApplicationRecord
     end
   end
 
-  def self.only_exact_matches(search_term, fields_to_search)
-    exact_matches = all.filter_map do |sorn|
-      sorn if sorn.search_term_found_in_any_selected_fields(search_term, fields_to_search)
-    end
-    Sorn.where(id: exact_matches.map(&:id))
-  end
-
   def search_term_found_in_any_selected_fields(search_term, fields_to_search)
     fields_to_search.any? do |field|
       field_content = self.send(field)

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -25,6 +25,23 @@ RSpec.describe "Search", type: :request do
     end
   end
 
+  context "multiword search" do
+    let(:search) { "FAKE SYSTEM NAME" }
+
+    it "succeeds" do
+      expect(response.successful?).to be_truthy
+    end
+
+    it "returns eveything expected on the card" do
+      expect(response.body).to include sorn.system_name
+      expect(response.body).to include sorn.agencies.first.name
+      expect(response.body).to include sorn.action
+      expect(response.body).to include sorn.publication_date
+      expect(response.body).to include sorn.citation
+      expect(response.body).to include sorn.html_url
+    end
+  end
+
   context "search with agency select" do
     let(:search) { "FAKE" }
     let(:fields) { nil }


### PR DESCRIPTION
We get exact results from multiword searches, using "ilike" sql rather than ruby. A third of the search time and a third of the memory. 

Using this ilike approach with the multiword search of "Social Security Number":
`Completed 200 OK in 2233ms (Views: 142.9ms | ActiveRecord: 2087.9ms | Allocations: 170460)`

On main with same search:
`Completed 200 OK in 6363ms (Views: 310.7ms | ActiveRecord: 5257.7ms | Allocations: 701484)`