### PR TITLE
Reduce pagination window

### DIFF
--- a/app/views/sorns/search.html.erb
+++ b/app/views/sorns/search.html.erb
@@ -81,12 +81,12 @@
         </div>
 
         <div class="grid-row margin-bottom-1">
-          <div class="grid-col-6">
+          <div class="grid-col-8">
             <div id="count" class="labels">
               <%= page_entries_info @sorns, entry_name: '' %> <%= 'for "' + params[:search] +'"' if params[:search].present? %>
             </div>
           </div>
-          <div class="grid-col-6">
+          <div class="grid-col-4">
               <%= paginate @sorns %>
           </div>
         </div>

--- a/app/views/sorns/search.html.erb
+++ b/app/views/sorns/search.html.erb
@@ -81,12 +81,12 @@
         </div>
 
         <div class="grid-row margin-bottom-1">
-          <div class="grid-col-8">
+          <div class="grid-col-7">
             <div id="count" class="labels">
               <%= page_entries_info @sorns, entry_name: '' %> <%= 'for "' + params[:search] +'"' if params[:search].present? %>
             </div>
           </div>
-          <div class="grid-col-4">
+          <div class="grid-col-5">
               <%= paginate @sorns %>
           </div>
         </div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -3,7 +3,7 @@
 Kaminari.configure do |config|
   config.default_per_page = 10
   # config.max_per_page = nil
-  config.window = 2
+  config.window = 1
   config.outer_window = 1
   # config.left = 0
   # config.right = 0


### PR DESCRIPTION
This PR adjusts the configuration for pagination, reducing the number of pages on either side of the current page. Similarly, adjust the columns to give more space for the search term, so it doesn't break to the next line on short search terms. 

A couple of examples of the layout:

![image](https://user-images.githubusercontent.com/52677065/105097503-b4269400-5a76-11eb-9852-20ba07b69979.png)

![image](https://user-images.githubusercontent.com/52677065/105097658-f94ac600-5a76-11eb-8f8b-da4dba666be0.png)
