### PR TITLE
No computer matching agreements

### DIFF
--- a/app/controllers/sorns_controller.rb
+++ b/app/controllers/sorns_controller.rb
@@ -17,11 +17,11 @@ class SornsController < ApplicationController
 
   def filter_on_search
     if @fields_to_search == Sorn::FIELDS
-      # If we are seaching the whole SORN, use the materialized view
-      @sorns = Sorn.no_computer_matching.where(id: FullSornSearch.search(params[:search]).select(:sorn_id))
+      # If we are searching the whole SORN, use the materialized view
+      @sorns = Sorn.where(id: FullSornSearch.search(params[:search]).select(:sorn_id))
     else
       # or search a list tsvectors columns
-      @sorns = Sorn.no_computer_matching.dynamic_search(@fields_to_search, params[:search])
+      @sorns = Sorn.dynamic_search(@fields_to_search, params[:search])
     end
   end
 

--- a/app/models/federal_register_client.rb
+++ b/app/models/federal_register_client.rb
@@ -87,7 +87,7 @@ class FederalRegisterClient
 
     # find the expected sorn titles
     # exclude any computer matching agreements
-    result.type == 'Notice' && a_sorn_title?(result.title) && not_a_cma?(result.action)
+    result.type == 'Notice' && a_sorn_title?(result.title) && not_a_cma?(result)
   end
 
   def a_sorn_title?(title)
@@ -95,9 +95,11 @@ class FederalRegisterClient
     title.match? /(privacy act|system[\ssof]*record)/i
   end
 
-  def not_a_cma?(action)
-    # no actions with the word match
-    action.downcase.exclude? 'match'
+  def not_a_cma?(result)
+    # no titles or actions with the word match
+    not_in_title = result.title.downcase.exclude?('match')
+    not_in_action = result.action.downcase.exclude?('match') if result.action.present?
+    not_in_title && not_in_action
   end
 
   def add_agencies(result, sorn)

--- a/app/models/federal_register_client.rb
+++ b/app/models/federal_register_client.rb
@@ -2,7 +2,7 @@ class FederalRegisterClient
   def initialize(conditions: nil, fields: nil)
     # Makes queries to the Federal Register API to find SORNs.
     # Searching for 'Privacy Act of 1974; System of Records' of type 'Notice' is the best query we have found.
-    @conditions = conditions || { term: 'Privacy Act of 1974; System of Records' } #, agencies: ['general-services-administration']
+    @conditions = conditions || { term: 'Privacy Act of 1974; System of Records' }
 
     # Find all available fields at
     # https://github.com/usnationalarchives/federal_register/blob/master/lib/federal_register/document.rb#L4
@@ -16,7 +16,7 @@ class FederalRegisterClient
       conditions: @conditions,
       type: 'NOTICE', # doesn't seem to work
       fields: @fields,
-      order: 'newest', #oldest
+      order: 'newest',
       per_page: 200,
       page: @page
     }
@@ -52,7 +52,6 @@ class FederalRegisterClient
 
   def handle_result(result)
     sorn = Sorn.find_by(citation: result.citation)
-
     params = sorn_params(result)
 
     if sorn
@@ -64,18 +63,6 @@ class FederalRegisterClient
     add_agencies(result, sorn)
 
     UpdateSornJob.perform_later(sorn.id)
-  end
-
-  def a_sorn_title?(title)
-    # We researched all Federal Register search result titles
-    # https://docs.google.com/document/d/15gwih9P6ebazWCS2ekxQ5Id1rDWbktg1mFdXtHIPZ44/edit#
-    # If a title includes one of these three, then we consider it a SORN.
-    patterns = ['privacy act', 'system[\ssof]*record', 'computer match']
-    patterns.any? { |pattern| title.match?(/#{pattern}/i) }
-  end
-
-  def sorn_result?(result)
-    result.type == 'Notice' && a_sorn_title?(result.title)
   end
 
   def sorn_params(result)
@@ -94,6 +81,25 @@ class FederalRegisterClient
     }
   end
 
+  def sorn_result?(result)
+    # We researched all Federal Register search result titles
+    # https://docs.google.com/document/d/15gwih9P6ebazWCS2ekxQ5Id1rDWbktg1mFdXtHIPZ44/edit#
+
+    # find the expected sorn titles
+    # exclude any computer matching agreements
+    result.type == 'Notice' && a_sorn_title?(result.title) && not_a_cma?(result.action)
+  end
+
+  def a_sorn_title?(title)
+    # titles with either privacy act or system of record
+    title.match? /(privacy act|system[\ssof]*record)/i
+  end
+
+  def not_a_cma?(action)
+    # no actions with the word match
+    action.downcase.exclude? 'match'
+  end
+
   def add_agencies(result, sorn)
     # add agency to sorn, without duplicates
     result.agencies.each do |api_agency|
@@ -103,8 +109,6 @@ class FederalRegisterClient
       end
     end
   end
-
-  private
 
   def get_agency_short_name(agency_api_id)
     FederalRegister::Agency.find(agency_api_id).short_name
@@ -130,9 +134,6 @@ class FederalRegisterClient
           parent_api_id: api_agency.parent_id,
           short_name: get_agency_short_name(api_agency.id)
         )
-      elsif agency.short_name.nil? # Can remove after everyone has short_name locally
-        agency.update(short_name: get_agency_short_name(api_agency.id))
-        return agency
       end
     end
   end

--- a/app/models/sorn.rb
+++ b/app/models/sorn.rb
@@ -97,8 +97,6 @@ class Sorn < ApplicationRecord
     action_type = case self.action
     when /Recertif*/i, /renew*/i, /re-establish*/i, /republicat*/i
       "Renewal"
-    when /match*/i
-      "Computer Matching Agreement"
     when /modif*/i, /alter*/i, /new blanket routine use/i, /amend*/i, /revis*/i, /change/i, /updat*/i, /new routine use/i
       "Modification"
     when /rescind*/i, /delet*/i, /resciss*/i, /retir*/i, /withdraw*/i

--- a/app/models/sorn.rb
+++ b/app/models/sorn.rb
@@ -7,7 +7,6 @@ class Sorn < ApplicationRecord
 
   validates :citation, uniqueness: true
 
-  scope :no_computer_matching, -> { where.not('"sorns"."action" ILIKE ?', '%matching%') }
   scope :get_distinct, -> { select(:id, Sorn::FIELDS + Sorn::METADATA).distinct }
   scope :get_distinct_with_dynamic_search_rank, -> { select(:id, Sorn::FIELDS + Sorn::METADATA,"#{PgSearch::Configuration.alias('sorns')}.rank").distinct }
   default_scope { order(publication_date: :desc) }

--- a/spec/models/federal_register_client_spec.rb
+++ b/spec/models/federal_register_client_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe FederalRegisterClient, type: :model do
   let(:title) { "Privacy Act of 1974; System of Records" }
+  let(:action) { "api action" }
   let(:type) { "Notice" }
   let(:pages) { 1 }
   let(:client) { described_class.new }
@@ -9,7 +10,7 @@ RSpec.describe FederalRegisterClient, type: :model do
   before do
     mock_result = OpenStruct.new(
       title: title,
-      action: "api action",
+      action: action,
       dates: "api dates",
       pdf_url: "pdf url",
       full_text_xml_url: "expected url",
@@ -208,10 +209,10 @@ RSpec.describe FederalRegisterClient, type: :model do
     end
 
     context "Computer matching" do
-      let(:title) { "Computer Matching" }
+      let(:action) { "Notice of a New Matching Program." }
 
-      it "creates a sorn" do
-        expect{ client.find_sorns }.to change{ Sorn.count }.by 1
+      it "does not create a SORN" do
+        expect{ client.find_sorns }.not_to change{ Sorn.count }
       end
     end
 

--- a/spec/models/federal_register_client_spec.rb
+++ b/spec/models/federal_register_client_spec.rb
@@ -209,10 +209,20 @@ RSpec.describe FederalRegisterClient, type: :model do
     end
 
     context "Computer matching" do
-      let(:action) { "Notice of a New Matching Program." }
+      context "in the title" do
+        let(:title) { "Privacy Act of 1974; Computer Matching Program" }
 
-      it "does not create a SORN" do
-        expect{ client.find_sorns }.not_to change{ Sorn.count }
+        it "does not create a SORN" do
+          expect{ client.find_sorns }.not_to change{ Sorn.count }
+        end
+      end
+
+      context "in the action" do
+        let(:action) { "Notice of a New Matching Program." }
+
+        it "does not create a SORN" do
+          expect{ client.find_sorns }.not_to change{ Sorn.count }
+        end
       end
     end
 

--- a/spec/models/sorn_spec.rb
+++ b/spec/models/sorn_spec.rb
@@ -135,22 +135,6 @@ RSpec.describe Sorn, type: :model do
   end
 
   describe ".get_action_type" do
-    context "Computer Matching Agreement" do
-      actions = ["Notice of a new matching program.",
-        "Notice of Computer Matching Program.",
-        "Notice of a Computer Matching Program Between HUD and DHS/FEMA.",
-        "Notice of a modified matching program."
-      ]
-
-      it "return expected action_type" do
-        actions.each do |action|
-          sorn.update(action: action)
-          sorn.get_action_type
-          expect(sorn.action_type).to eq "Computer Matching Agreement"
-        end
-      end
-    end
-
     context "New" do
       actions = ["new something", "Notice of system of records.",
         "Notice of Privacy Act system of records.", "Adding a system",


### PR DESCRIPTION
This PR stops including the computer matching agreements. Our user research has told us to not include them in our service.

While writing this PR, I discovered we had a bunch of computer matching agreements we didn't know about. We were only checking the `action` for them, yet there were hundreds that had nondescript `action` but had a `title` saying it was a computer matching agreement.

We now check both `title` and `action` and exclude any matching agreements.

I've done a full `find_sorns` job locally with this code and it worked.
### Notes
After deploying, we should delete existing CMAs from our current servers and local machines.
```
Sorn.where('action ILIKE ?', '%match%').destroy_all
Sorn.where('title ILIKE ?', '%match%').destroy_all
```