### PR TITLE
clean up csv link

### DIFF
--- a/app/helpers/sorns_helper.rb
+++ b/app/helpers/sorns_helper.rb
@@ -8,8 +8,7 @@ module SornsHelper
   end
 
   def csv_params
-    csv_params = {
-      search: params[:search],
+    { search: params[:search],
       fields: @fields_to_search,
       agencies: params[:agencies],
       starting_year: params[:starting_year],

--- a/app/helpers/sorns_helper.rb
+++ b/app/helpers/sorns_helper.rb
@@ -6,4 +6,15 @@ module SornsHelper
   def agency_selected?(agency_name)
     params[:agencies]&.include?(agency_name)
   end
+
+  def csv_params
+    csv_params = {
+      search: params[:search],
+      fields: @fields_to_search,
+      agencies: params[:agencies],
+      starting_year: params[:starting_year],
+      ending_year: params[:ending_year],
+      format: :csv
+    }
+  end
 end

--- a/app/views/sorns/search.html.erb
+++ b/app/views/sorns/search.html.erb
@@ -36,7 +36,7 @@
           </div>
         </div>
         <div id="csv-download">
-          <%= link_to search_path(search: params[:search], fields: @fields_to_search, agencies: params[:agencies], starting_year: params[:starting_year], ending_year: params[:ending_year], format: :csv) do %>
+          <%= link_to search_path csv_params do %>
             <%= image_tag "Download_Icon.svg"%>
             <span class="csv-download-link-text">Download results as a CSV file</span>
           <% end %>

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -159,9 +159,9 @@ RSpec.describe "Search", type: :request do
 
   context "csv link" do
     it "has the right params" do
-      get "/search?search=different&fields[]=citation&agencies[]=Parent+Agency&starting_year=2019&ending_year=2020"
+      get "/search?search=different&fields[]=categories_of_record&agencies[]=Parent+Agency&starting_year=2019&ending_year=2020"
 
-      expect(response.body).to include '<a href="/search.csv?agencies%5B%5D=Parent+Agency&amp;ending_year=2020&amp;fields%5B%5D=citation&amp;search=different&amp;starting_year=2019">'
+      expect(response.body).to include '<a href="/search.csv?agencies%5B%5D=Parent+Agency&amp;ending_year=2020&amp;fields%5B%5D=categories_of_record&amp;search=different&amp;starting_year=2019">'
     end
   end
 end


### PR DESCRIPTION
This PR makes our csv link more readable, and fixes a broken test.

The test was searching against the "citation" column, but we don't have that metadata column in our list of search columns anymore.