### PR TITLE
found-section-snippet remove margins

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -401,6 +401,15 @@
  .found-section-snippet {
   font-size: 16px;
   width: 100%;
+  margin-top: 0px;
+
+  p:first-child {
+    margin-top: 0px;
+  }
+
+  p:last-child {
+    margin-bottom: 0px;
+  }
 
  }
 


### PR DESCRIPTION
add css rules to remove whitespace before and after some of `.found-in-snippet` excerpts.