### PR TITLE
Card style updates

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -366,6 +366,7 @@
  }
 
  .sorn-attribute-header {
+  color: $blue-90;
   font-weight: bold;
  }
 
@@ -389,6 +390,8 @@
  }
 
  .found-in {
+  font-size: .9em;
+  margin: 0 0 1em;
   width: 100%;
  }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,7 @@
  $blue-50:      #006DB6; // Interactive
  $blue-10V:     #CFE8FF;
 
+ $gray-cool-60: #565c65;
  $gray-cool-30: #A9AEB1;
  $gray-cool-2:  #F7F9FA;
  $gray-5:       #F0F0F0;
@@ -390,6 +391,7 @@
  }
 
  .found-in {
+  color: $gray-cool-60;
   font-size: .9em;
   margin: 0 0 1em;
   width: 100%;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -392,7 +392,8 @@
 
  .found-in {
   color: $gray-cool-60;
-  font-size: .9em;
+  font-size: .85em;
+  letter-spacing: .04em;
   margin: 0 0 1em;
   width: 100%;
  }
@@ -417,8 +418,12 @@
 
  }
 
+.usa-card__body .grid-row:last-of-type {
+  padding-bottom: 0;
+}
+
  .usa-card__footer {
-  padding: 16px;
+  padding: 8px 16px 16px;
  }
 
  .usa-link--external {

--- a/app/views/sorns/search.html.erb
+++ b/app/views/sorns/search.html.erb
@@ -145,7 +145,7 @@
                   <hr />
 
                   <div class="grid-row">
-                    <h3 class='found-in'>FOUND IN</h4>
+                    <h3 class='found-in'>FOUND IN</h3>
                     <% sorn.section_snippets(@fields_to_search.map(&:to_s), params[:search]).each do |section, snippet| %>
                       <div class="grid-row">
                         <div class='sorn-attribute-header'><%= section.humanize %></div>


### PR DESCRIPTION
This PR includes style updates to the card:
1. Change the field label header color to add some more distinction from the body text 
2. Change the color and reducing the size of `Found in` to differentiate it further from section names 
3. Reduces space at the bottom of the card to shorten the height of the cards and better balance the white space. 

PR:
![image](https://user-images.githubusercontent.com/52677065/106017716-c1530c80-608e-11eb-8a2d-7e630063d034.png)


Current:
![image](https://user-images.githubusercontent.com/52677065/106017743-cc0da180-608e-11eb-9a4c-bef414429334.png)

