### PR TITLE
Make sure goodjob is running for daily updates.

### DIFF
--- a/.github/workflows/sorn-grab.yml
+++ b/.github/workflows/sorn-grab.yml
@@ -17,4 +17,5 @@ jobs:
           cf auth ${{ secrets.CF_USERNAME }} ${{ secrets.CF_PASSWORD }}
           cf target -o ${{ secrets.CF_ORG }} -s ${{ secrets.CF_SPACE }}
           cf run-task all_sorns "bundle exec rails federal_register:find_sorns" --name "Find SORNs"
+          cf run-task all_sorns "bundle exec good_job start" --name "Start GoodJob"
           echo "Daily update queued"


### PR DESCRIPTION
We check for new SORNs every night at 2:11am eastern. We need make sure our job runner is up and running then too. This adds a cloud foundry task request to start GoodJob every night as well. It will be ignored if it is already running.