### PR TITLE
Mobile style

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -37,8 +37,15 @@ $font-stack: Source Sans Pro Web,Helvetica Neue,Helvetica,Roboto,Arial,sans-seri
   &.pre-search {
     background-image: image-url("PrvOps_SornDash_Landing_02.svg");
     background-repeat: no-repeat;
-    background-position: -3em 80%;
+    background-position: -3em 65%;
+
+    @media screen and (min-width: 64em) {
+      background-position: -3em 80%;
+    }
+
   }
+
+
  }
 
  // Header & Navigation
@@ -276,7 +283,7 @@ $font-stack: Source Sans Pro Web,Helvetica Neue,Helvetica,Roboto,Arial,sans-seri
 
  .labels {
   font-size: 1.2em;
-  padding-bottom: 8px;
+  padding-bottom: .5em;
   color: $blue-80V;
  }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -152,6 +152,11 @@ $font-stack: Source Sans Pro Web,Helvetica Neue,Helvetica,Roboto,Arial,sans-seri
 }
 
 //Sidebar
+.usa-layout-docs__sidenav {
+  order: 0;
+  padding: 0 .5rem 1.5rem;
+}
+
 .sidebar h2 {
   padding: 1.25rem 1rem 0rem 1.25rem;
   font-family: $font-stack;
@@ -270,6 +275,7 @@ $font-stack: Source Sans Pro Web,Helvetica Neue,Helvetica,Roboto,Arial,sans-seri
  }
 
  .labels {
+  font-size: 1.2em;
   padding-bottom: 8px;
   color: $blue-80V;
  }
@@ -376,6 +382,17 @@ $font-stack: Source Sans Pro Web,Helvetica Neue,Helvetica,Roboto,Arial,sans-seri
    padding: 0 0.5rem;
    font-weight: bold;
  }
+
+ .pub-details {
+   div:first-of-type {
+    padding-bottom: 16px;
+
+    @media screen and (min-width: 640px) {
+      padding-bottom: 0;
+    }
+   }
+ }
+
 
  .sorn-history__list {
    list-style-position: inside;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <title><%= @title%>SORNS Dash</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.9.0/css/uswds.min.css" integrity="sha512-1JfROzJI5km8+inC3KrHAsJ4Ufjl2nD7/TbCBXoMUeXi0LIAZntfLQr2S6ifV0lCuO0mWOOlNJNTgKzkj7b7wA==" crossorigin="anonymous" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/uswds/2.9.0/js/uswds.min.js" integrity="sha512-DK4Dfv782z/2seHu61hJL5WvFg95vZ64fKsqzeV7vTNcx01Ajp1kq5+w0QUNQ6GSakYyj6Mw0LZ/ddL5rNVMYQ==" crossorigin="anonymous"></script>
 

--- a/app/views/sorns/search.html.erb
+++ b/app/views/sorns/search.html.erb
@@ -167,8 +167,11 @@
 
 
         </ul>
-        <div class="grid-row grid-offset-9 padding-y-3 padding-left-4">
-          <%= paginate @sorns %>
+        <div class="grid-row">
+          <div class="grid-col-12">
+              <%= paginate @sorns %>
+          </div>
+
         </div>
       </main>
     <% end %>

--- a/app/views/sorns/search.html.erb
+++ b/app/views/sorns/search.html.erb
@@ -9,7 +9,7 @@
 
 <%= form_tag '/', method: "GET", id: "search-form", class: (params[:search].present? ? '' : 'pre-search') do %>
   <section class="grid-container">
-    <div class="grid-col-10 grid-offset-1 search-area">
+    <div class="desktop:grid-col-10 desktop:grid-offset-1 search-area">
       <label for="general-search">Search for SORNs by entering a keyword (will return exact matches)</label>
       <fieldset class="usa-search usa-search--big">
         <input class="usa-input" id="general-search" type="search" name="search" value="<%= params[:search] %>"></input>
@@ -24,7 +24,7 @@
   <div class="grid-container margin-top-2">
     <div class ="grid-row grid-gap">
 
-      <div class="usa-layout-docs__sidenav grid-col-4">
+      <div class="usa-layout-docs__sidenav desktop:grid-col-4">
         <div class="border border-base-dark sidebar">
           <div class="preview usa-prose site-prose" >
             <h2>Refine your search</h2>
@@ -43,7 +43,7 @@
         </div>
       </div>
 
-      <main class="usa-layout-docs__main usa-prose usa-layout-docs grid-col-8" id="main-content">
+      <main class="usa-layout-docs__main usa-prose usa-layout-docs desktop:grid-col-8" id="main-content">
         <div id="active-filters">
           <div id="active-sections-filters">
             <div class="grid-row">
@@ -81,12 +81,12 @@
         </div>
 
         <div class="grid-row margin-bottom-1">
-          <div class="grid-col-7">
+          <div class="grid-col-12">
             <div id="count" class="labels">
               <%= page_entries_info @sorns, entry_name: '' %> <%= 'for "' + params[:search] +'"' if params[:search].present? %>
             </div>
           </div>
-          <div class="grid-col-5">
+          <div class="grid-col-12">
               <%= paginate @sorns %>
           </div>
         </div>
@@ -111,12 +111,12 @@
                       <%= sorn.action %>
                     </div>
                   </div>
-                  <div class="grid-row">
-                    <div class="grid-col-6">
+                  <div class="grid-row pub-details">
+                    <div class="tablet:grid-col-6">
                       <span class="sorn-attribute-header">Publication Date:</span>
                       <%= sorn.publication_date %>
                     </div>
-                    <div class="grid-col-6">
+                    <div class="tablet:grid-col-6">
                       <span class="sorn-attribute-header">Citation:</span>
                       <a target="_blank" class="usa-link usa-link--external" href="<%= sorn.html_url %>" rel="noreferrer noopener"><%= sorn.citation %></a>
                     </div>


### PR DESCRIPTION
This PR adds styling for improved layouts on mobile and tablet devices. Also adjust the count and pagination on desktop devices to move them to their individual lines to prevent awkward breaks. 

PR:
![image](https://user-images.githubusercontent.com/52677065/106333085-f65d8b80-6255-11eb-8fed-12abf66345cb.png)

Current:
![image](https://user-images.githubusercontent.com/52677065/106333684-3709d480-6257-11eb-8fd7-3cb1092985f8.png)
