### PR TITLE
Fix a bug with sorn agency relationships

### DIFF
--- a/app/models/federal_register_client.rb
+++ b/app/models/federal_register_client.rb
@@ -130,13 +130,14 @@ class FederalRegisterClient
     if api_agency.id.present? # skip the subcomponents without metadata, "Office of the Secretary"
       agency = Agency.find_by(api_id: api_agency.id)
       if agency.nil?
-        Agency.create(
+        agency = Agency.create(
           name: api_agency.raw_name.titleize,
           api_id: api_agency.id,
           parent_api_id: api_agency.parent_id,
           short_name: get_agency_short_name(api_agency.id)
         )
       end
+      return agency
     end
   end
 end

--- a/spec/models/federal_register_client_spec.rb
+++ b/spec/models/federal_register_client_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe FederalRegisterClient, type: :model do
         expect(Sorn.last.agencies.first.short_name).to eq "Child"
       end
 
-      context "with existing agencies" do
+      context "sorn with existing agencies" do
         let(:sorn) { create :sorn, agencies: [] }
 
         before do
@@ -88,6 +88,22 @@ RSpec.describe FederalRegisterClient, type: :model do
         it "Doesn't duplicate agencies" do
           client.find_sorns
           expect(sorn.agencies.count).to eq 2
+        end
+      end
+
+      context "agencies already exist before the sorn" do
+        let(:sorn) { create :sorn, agencies: [] }
+
+        before do
+          Agency.create(name: "Parent Agency", api_id: 1, parent_api_id: nil, short_name: "Parent")
+          Agency.create(name: "Child Agency", api_id: 2, parent_api_id: 1, short_name: "Child")
+        end
+
+        it "still creates correct relationship" do
+          client.find_sorns
+
+          expect(Sorn.last.agencies.second).to have_attributes(name: "Parent Agency", api_id: 1, parent_api_id: nil)
+          expect(Sorn.last.agencies.first).to have_attributes(name: "Child Agency", api_id: 2, parent_api_id: 1)
         end
       end
 


### PR DESCRIPTION
Agencies were only having one sorn. the `if sorn.nil?` check would cause the function to return nil, instead of the existing agency. Added an explicit return at the bottom to fix. 

Also added a spec to catch this in the future.