### PR TITLE
Js only on the search page.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,8 +17,7 @@
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application' %>
 
-    <%= javascript_pack_tag 'beforeSearch' %>
-
+    <%= content_for :search %>
  </head>
 
   <body <%if params[:search].blank? && current_page?('/') %>class="pre-search"<%end%>>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,3 +1,7 @@
+<% content_for :search do %>
+  <%= javascript_pack_tag 'beforeSearch' %>
+<% end %>
+
 <header id="search-header" class="margin-top-2 home-intro">
   <div class="grid-container site-intro">
     <div class="grid-row grid-gap grid-col-9">

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -147,4 +147,16 @@ RSpec.describe "Search", type: :request do
       expect(response.body).to include "<mark>FAKE<\\/mark> ACTION" # Newer citation
     end
   end
+
+  context "including beforeSearch.js pack" do
+    it "included on main search page" do
+      get "/"
+      expect(response.body).to include '/packs-test/js/beforeSearch-'
+    end
+
+    it "not on the about page" do
+      get "/about"
+      expect(response.body).to_not include '/packs-test/js/beforeSearch-'
+    end
+  end
 end


### PR DESCRIPTION
This PR prevents the loading of search specific js while on the other non-search pages. We were getting a little js error on those other pages. The error wasn't breaking anything, but this PR prevents it from happening.

Includes a test.