### PR TITLE
Fix flaky csv url spec

### DIFF
--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe "/", type: :system do
     #  browse mode is bare link
     visit "/"
     find("#general-search-button").click
-    expect(page).to have_link href: "/search.csv"
+    expect(page).to have_link href: "search.csv?search=&starting_year=&ending_year="
     # search params
     fill_in "general-search", with: "SEARCH FOR THIS"
     find("#general-search-button").click


### PR DESCRIPTION
Makes a flaky test assertion more precise and easier for the computers to handle. [Capybara](https://github.com/teamcapybara/capybara), which does our headless browser integration tests, does its best to interpret assertions of what it is looking for on a page. It will even wait a bit to give any js a change to work first. This small edit lets Capybara find the link fast.

I'm still not 100% on why it was flaky. I can reproduce it locally by adding a half second sleep before the assertion, getting it to fail every time. It makes no sense.

This flaky test has failed a few times on the deploy step, after passing when the tests first ran. I've clicked "Rerun job" which fixes it each time. I'm unable to link to a failure, because Github Action removes it when you manually rerun a job, yet you probably got emails about them failing.

Closes #186 