### PR TITLE
Add run condition on repository owner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   deploy:
+    if: github.repository_owner == '18F'
     name: Deploy to cloud.gov
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sorn-grab.yml
+++ b/.github/workflows/sorn-grab.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   find-sorns:
+    if: github.repository_owner == '18F'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
For all workflows that contain secrets that are not meant to be shared
with clones/forks/etc, adding a job condition on the repository owner
prevents those copies from needlessly running a job that will always
fail due to those secrets either not existing or being incorrect.
