### PR TITLE
Run jobs on the main web server instance

### DIFF
--- a/.github/workflows/sorn-grab.yml
+++ b/.github/workflows/sorn-grab.yml
@@ -20,5 +20,4 @@ jobs:
           cf auth ${{ secrets.CF_USERNAME }} ${{ secrets.CF_PASSWORD }}
           cf target -o ${{ secrets.CF_ORG }} -s ${{ secrets.CF_SPACE }}
           cf run-task all_sorns "bundle exec rails federal_register:find_sorns" --name "Find SORNs"
-          cf run-task all_sorns "bundle exec good_job start" --name "Start GoodJob"
           echo "Daily update queued"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,9 +1,12 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Run our goodjob job's on the main web server machine.
+  config.good_job.execution_mode = :async
+
   #Tighten the cookies on prod but not in lower envs
   config.session_store :cookie_store, same_site: :strict
-  
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/docs/devops.md
+++ b/docs/devops.md
@@ -10,9 +10,9 @@ FISMA-low environment.
 On cloud.gov, there is a production space and a staging space. These spaces each contain:
 - 1 instance of the `all-sorns` application. By default it uses 1G of memory and 1G of disk space.
 - 1 Postgres database, at least v12.
-- 2G of memory in reserve for each space, to run the GoodJob job runner task, and the nightly [find_sorns_job](https://github.com/18F/all_sorns/blob/main/app/jobs/find_sorns_job.rb) task.
+- 1G of memory in reserve for each space, to run the nightly [find_sorns_job](https://github.com/18F/all_sorns/blob/main/app/jobs/find_sorns_job.rb) task.
 
-In total this is at least 6G of memory needed for the org amount, for both environments to fully run.
+In total this is at least 4G of memory needed for the org amount, for both environments to fully run.
 
 ### Deploying
 
@@ -36,7 +36,7 @@ script does the following:
 
 ### **Repo**
 
-All SORN DASH code is kept and managed in this public Github repository: [https://github.com/18F/all\_sorns](https://github.com/18F/all_sorns)
+All SORN DASH code is kept and managed in this public Github repository: [https://github.com/18F/all_sorns](https://github.com/18F/all_sorns)
 
 All SORN Dash code is open source under a **CC0 license**.
 


### PR DESCRIPTION
Talked to the creator of our job worker library, GoodJob. He suggested our use case fits well with running the job workers on the web server machine itself, https://github.com/bensheldon/good_job#execute-jobs-async--in-process. If we had thousands of jobs going all day, we'd need to have them run elsewhere, but with our once a day job its fine.

This would leave us with only one task that needs to be run at night, needing only one extra gig of memory to be available.

I tested this on our 10x development server https://allsornsdev.app.cloud.gov/. With no job runner tasks going, I enqueued a `find_sorns` job using a task. Watching the logs, it started working immediately. Brand new SORNs showed up on the site. 👍 
