### PR TITLE
Switch to yarn cache for js dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,33 +29,39 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.1
           # runs 'bundle install' and caches installed gems automatically
           bundler-cache: true
+
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
           node-version: 14
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: npm-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            npm-${{ runner.os }}-build-${{ env.cache-name }}-
-            npm-${{ runner.os }}-build-
-            npm-${{ runner.os }}-
+
       - name: Install linux dependencies
         run: |
           sudo apt-get -yqq install libpq-dev build-essential libssl-dev
+
       - name: install javascript dependencies
         run: yarn install
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Setup test database
         env:
           RAILS_ENV: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,13 +42,6 @@ jobs:
         with:
           node-version: 14
 
-      - name: Install linux dependencies
-        run: |
-          sudo apt-get -yqq install libpq-dev build-essential libssl-dev
-
-      - name: install javascript dependencies
-        run: yarn install
-
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -61,6 +54,13 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
+      - name: Install linux dependencies
+        run: |
+          sudo apt-get -yqq install libpq-dev build-essential libssl-dev
+
+      - name: install javascript dependencies
+        run: yarn install
 
       - name: Setup test database
         env:


### PR DESCRIPTION
It appears to me that the installs are being done with `yarn` instead of `npm` so switching the caching mechanism to the one for yarn as outlined in the [actions/cache - yarn example](https://github.com/actions/cache/blob/main/examples.md#node---yarn) seems appropriate.