### PR TITLE
Upgrade cf cli to v7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install cf cli
         run: |
-          brew install cloudfoundry/tap/cf-cli
-          cf install-plugin blue-green-deploy -r CF-Community -f
+          curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v7&source=github" | sudo tar -zx --directory=/usr/local/bin
+          cf --version
       - name: Deploy to cloud.gov
         env:
           CF_USERNAME: ${{ secrets.CF_USERNAME }}


### PR DESCRIPTION
Upgrading to version 7 of the CF cli as v6 is in the process of being
deprecated. According to
https://github.com/cloudfoundry/cli/wiki/Versioning-and-Support-Policy,
"All new features, enhancements, and fixes will be made on the v7 CLI.
The v6 CLI will only be updated to resolve the most severe defects
and/or security issues."

The installation method for installing the cli has also been changed
from Homebrew to using the compressed binary for speed purposes in the
github actions workflow.