### PR TITLE
Pin Postgres version in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres
+        image: postgres:12
         env:
           POSTGRES_USER: all_sorns
           POSTGRES_DB: all_sorns_test


### PR DESCRIPTION
With the latest (14.0) release of Postgres, the test workflow is failing
due to pg_dump server version mismatch errors. As the SORN project is
using an AWS RDS instance that runs on Postgres version 12.x the ci/cd
pipeline should never be using a different version. Pinning the version
in the test workflow should allow for much more stable and accurate
testing.
