### PR TITLE
Add test success condition on deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-    if: github.repository_owner == '18F'
+    if: github.repository_owner == '18F' && ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Deploy to cloud.gov
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Currently the deploy workflow will run on every completed run of the
test workflow which is dangerous at best. If the test workflow fails,
the deployment workflow should never be kicked off. This logic error can
be fixed by adding a conditional to the deploy action that checks the
success status of the triggering workflow_run. See
https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_run
