### PR TITLE
Return bad request status for null byte in params

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,34 @@
 class ApplicationController < ActionController::Base
+    before_action :reject_requests_with_invalid_characters
+
+    INVALID_CHARACTERS = [
+        "\u0000" # null bytes
+    ].freeze
+
+    private
+
+    def reject_requests_with_invalid_characters
+        if has_invalid_character?(request.params.values)
+            raise ActionController::BadRequest
+        end
+    end
+
+    # Currently checks strings and arrays in param values
+    def has_invalid_character?(param_values)
+        param_values.any? do |value|
+            if value.respond_to?(:match)
+                string_contains_invalid_character?(value)
+            elsif value.is_a?(Array)
+                value.any? do |array_value|
+                    string_contains_invalid_character?(array_value) if array_value.respond_to?(:match)
+                end
+            end
+        end
+    end
+
+    def string_contains_invalid_character?(string)
+        invalid_characters_regex = Regexp.union(INVALID_CHARACTERS)
+
+        string.match?(invalid_characters_regex)
+    end
 end

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -159,4 +159,22 @@ RSpec.describe "Search", type: :request do
       expect(response.body).to_not include '/packs-test/js/beforeSearch-'
     end
   end
+
+  context 'when sent invalid characters' do
+    context 'in string params' do
+      it 'raises bad request exception' do
+        expect do
+          get search_path, params: { search: "\u0000" }, xhr: true
+        end.to raise_error(ActionController::BadRequest)
+      end
+    end
+
+    context 'in array params' do
+      it 'raises bad request exception' do
+        expect do
+          get search_path, params: { agencies: ["\u0000", "abcdef"] }, xhr: true
+        end.to raise_error(ActionController::BadRequest)
+      end
+    end
+  end
 end


### PR DESCRIPTION
A null byte sent in any of the parameters is unexpected and when
searching will cause some issues if passed through. To prevent that, this
checks all params of any request and sends back a 'bad request' status if a
null byte is found by raising the error and letting Rails do its thing.

Pattern based off of http://joshfrankel.me/blog/don-t-let-the-null-bytes-bite/

Closes #270 