### PR TITLE
Fix agency filtering

### DIFF
--- a/app/models/sorn.rb
+++ b/app/models/sorn.rb
@@ -7,7 +7,7 @@ class Sorn < ApplicationRecord
 
   validates :citation, uniqueness: true
 
-  scope :get_distinct_with_dynamic_search_rank, -> { select(:id, Sorn::FIELDS + Sorn::METADATA,"#{PgSearch::Configuration.alias('sorns')}.rank").distinct }
+  scope :get_distinct_with_dynamic_search_rank, -> { select(Sorn.attribute_names,"#{PgSearch::Configuration.alias('sorns')}.rank").distinct }
   default_scope { order(publication_date: :desc) }
 
   FIELDS = [
@@ -38,26 +38,6 @@ class Sorn < ApplicationRecord
     :notification,
     :exemptions,
     :history
-  ]
-
-  METADATA = [
-    :html_url,
-    :xml_url,
-    :citation,
-    :title,
-    :publication_date,
-    :action_type
-  ]
-
-  DEFAULT_FIELDS = [
-    'agency_names',
-    'action',
-    'system_name',
-    'summary',
-    'categories_of_individuals',
-    'categories_of_record',
-    'html_url',
-    'publication_date'
   ]
 
   include PgSearch::Model

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Search", type: :request do
   let(:agency) { nil }
 
   before do
-    get search_path, params: {search: search, fields: fields, agency: agency}, xhr: true
+    get search_path, params: {search: search, fields: fields, agencies: agency}, xhr: true
   end
 
   context "search" do
@@ -43,8 +43,6 @@ RSpec.describe "Search", type: :request do
   end
 
   context "search with agency select" do
-    let(:search) { "FAKE" }
-    let(:fields) { nil }
     let(:agency) { "Parent Agency" }
 
     it "succeeds" do
@@ -64,10 +62,6 @@ RSpec.describe "Search", type: :request do
     context "agency search with overlapping SORNs" do
       let(:fields) { ['system_name'] }
       let(:agency) { ['Parent Agency', 'Child Agency'] }
-
-      before do
-        sorn.agencies << create(:agency, name: "Child Agency", short_name: "CA")
-      end
 
       it "only returns a single SORN, even though it matches the two agencies" do
         expect(response.body).to include "Displaying <b>1<\\/b>  for &quot;FAKE"


### PR DESCRIPTION
An attribute (xml) we need for displaying the SORNS was accidentally
left out of the list of attributes the agency filtering scope returns.
To fix and avoid this in the future, we now select *all* database
attributes when using the scope.

Also updates a test to make sure code path it tests is triggered;
parameter was incorrectly named before, making it pass incorrectly.

Signed-off-by: Natasha Ibrahim <natasha.ibrahim@gsa.gov>

Closes https://github.com/18F/all_sorns/issues/195