### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ installed and install the necessary project dependencies.
 
 ```bash
 gem install bundler
-gem install yarn
+brew install node
+npm install --global yarn
 ```
 
 Install the necessary project dependencies using:
@@ -71,7 +72,7 @@ yarn install --check-files
 
 Now that you have the environment set-up, create the database:
 
-`bundle exec rails db:setup`
+`bundle exec rails db:create db:migrate`
 
 Once this is complete, run the following command to fetch all the SORNs
 from the Federal Register API and populate your local database (this


### PR DESCRIPTION
👋 Just a quick little README update. Let me know if you have any questions. Feedback welcomed.

- The [yarn gem](https://rubygems.org/gems/yarn/versions/0.1.1) has not been updated since 2011 and is currently broken. I think the current recommendation is to use npm to manage yarn.   

- The following error occurs when you run `bundle exec rake db:schema:load`
  ```
  rails aborted!
  ActiveRecord::StatementInvalid: PG::FeatureNotSupported: ERROR:  cannot use column reference in DEFAULT 
  expression
  LINE 1: ...FAULT to_tsvector('english'::regconfig, (COALESCE(agency_nam...
  ```
  This app is so small that I think it's fine if we just rebuild and migrate the db on setup. 
  I didn't dig into this much but I assume it's something to do with how the schema is being built. 
  There's no apparent difference between the schema on master and a new one when I recreate it locally.