### PR TITLE
Add prod route to deployment script

### DIFF
--- a/.cloud-gov/deploy.sh
+++ b/.cloud-gov/deploy.sh
@@ -60,6 +60,7 @@ else
 	cf push all_sorns -f .cloud-gov/manifest.yml --no-route
 fi
 cf map-route all_sorns app.cloud.gov --hostname "$CGHOSTNAME"
+cf map-route all_sorns sorndashboard.fpc.gov
 
 # tell people where to go
 echo


### PR DESCRIPTION
Adding the `map-route` command to always keep the production URL mapping live after a new version is pushed.