### PR TITLE
Prevent routing of requests with arbitrary formats

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,9 @@ Rails.application.routes.draw do
 
   get '/search', to: 'search#search'
 
-  get '/analytics', to: 'analytics#index'
+  get '/analytics', to: 'analytics#index', format: false
 
-  get '/about', to: 'pages#about'
+  get '/about', to: 'pages#about', format: false
 
-  get '/help', to: 'pages#help'
+  get '/help', to: 'pages#help', format: false
 end


### PR DESCRIPTION
By adding "format: false" to the route configuration for static pages,
the application will no longer respond to requests of the form
"sorn.gov/help.abcd" or "sorn.gov/help.bac", etc. The only valid request
to a page such as the /help page is now /help with no extensions and/or
dot suffix.

Addresses the "Backup File Disclosure" ZAP finding.