### PR TITLE
Fix the nightly find_sorns action

### DIFF
--- a/.github/workflows/sorn-grab.yml
+++ b/.github/workflows/sorn-grab.yml
@@ -11,13 +11,12 @@ jobs:
     if: github.repository_owner == '18F'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Install cf cli
-        run: brew install cloudfoundry/tap/cf-cli
-      - name: Login and update
-        run: |
-          cf api https://api.fr.cloud.gov
-          cf auth ${{ secrets.CF_USERNAME }} ${{ secrets.CF_PASSWORD }}
-          cf target -o ${{ secrets.CF_ORG }} -s ${{ secrets.CF_SPACE }}
-          cf run-task all_sorns "bundle exec rails federal_register:find_sorns" --name "Find SORNs"
-          echo "Daily update queued"
+      - name: Run update task
+        uses: 18f/cg-deploy-action@main
+        with:
+          cf_username: ${{ secrets.CF_USERNAME }}
+          cf_password: ${{ secrets.CF_PASSWORD }}
+          cf_org: ${{ secrets.CF_ORG }}
+          cf_space: ${{ secrets.CF_SPACE }}
+          full_command: |
+            cf run-task all_sorns "bundle exec rails federal_register:find_sorns" --name "Find SORNs"


### PR DESCRIPTION
It looks like the `ubuntu-latest` update that happened no longer has `brew` installed. This change uses https://github.com/18f/cg-deploy-action to kick off the task instead.