### PR TITLE
Update Cloud Foundry stack to cflinuxfs4

### DIFF
--- a/.cloud-gov/manifest-dev.yml
+++ b/.cloud-gov/manifest-dev.yml
@@ -3,6 +3,7 @@
   - name: all_sorns_dev
     buildpacks:
       - ruby_buildpack
+    stack: cflinuxfs4
     memory: 1G
     services:
       - all-sorns-db-dev

--- a/.cloud-gov/manifest.yml
+++ b/.cloud-gov/manifest.yml
@@ -3,6 +3,7 @@
   - name: all_sorns
     buildpacks:
       - ruby_buildpack
+    stack: cflinuxfs4
     memory: 1G
     services:
       - all-sorns-db


### PR DESCRIPTION
cflinuxfs3 is obsolete and no longer supported