### PR TITLE
Set route properly for test env

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -24,5 +24,4 @@ jobs:
           CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
           CF_ORG: ${{ secrets.CF_ORG }}
           CF_SPACE: ${{ secrets.CF_SPACE }}
-          CF_CGHOSTNAME: test
         run: ./.cloud-gov/deploy.sh rolling

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -24,5 +24,5 @@ jobs:
           CF_PASSWORD: ${{ secrets.CF_PASSWORD_TEST }}
           CF_ORG: ${{ secrets.CF_ORG }}
           CF_SPACE: ${{ secrets.CF_SPACE_TEST }}
-          CF_CGHOSTNAME: all-sorns-test
+          CGHOSTNAME: all-sorns-test
         run: ./.cloud-gov/deploy.sh rolling


### PR DESCRIPTION
Previously we were specifying an env var that was ignored by the script, which then tried to use the default name for the route and hit a collision with the prod space's route.