### PR TITLE
Update to rails 6-1-stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,11 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '~> 3.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 6.1.4', '>= 6.1.4.6'
+
+# We need to use rails 6-1.stable to get around a problem with good_job:
+# https://github.com/bensheldon/good_job/issues/1016#issuecomment-1644915406
+gem 'rails', github: "rails/rails", branch: '6-1-stable'
+# gem 'rails', '~> 6.1.4', '>= 6.1.4.6'
 gem 'good_job', '>= 1.13.2'
 gem 'pg'
 gem 'httparty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,7 @@
-GEM
-  remote: https://rubygems.org/
+GIT
+  remote: https://github.com/rails/rails.git
+  revision: 1540cb381b4c78f1bcd7e081717a9e0a6706a9d8
+  branch: 6-1-stable
   specs:
     actioncable (6.1.7.6)
       actionpack (= 6.1.7.6)
@@ -60,6 +62,31 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    rails (6.1.7.6)
+      actioncable (= 6.1.7.6)
+      actionmailbox (= 6.1.7.6)
+      actionmailer (= 6.1.7.6)
+      actionpack (= 6.1.7.6)
+      actiontext (= 6.1.7.6)
+      actionview (= 6.1.7.6)
+      activejob (= 6.1.7.6)
+      activemodel (= 6.1.7.6)
+      activerecord (= 6.1.7.6)
+      activestorage (= 6.1.7.6)
+      activesupport (= 6.1.7.6)
+      bundler (>= 1.15.0)
+      railties (= 6.1.7.6)
+      sprockets-rails (>= 2.0.0)
+    railties (6.1.7.6)
+      actionpack (= 6.1.7.6)
+      activesupport (= 6.1.7.6)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     bindex (0.8.1)
@@ -153,7 +180,7 @@ GEM
     minitest (5.20.0)
     msgpack (1.5.4)
     multi_xml (0.6.0)
-    net-imap (0.3.7)
+    net-imap (0.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -194,21 +221,6 @@ GEM
       rack
     rack-test (2.1.0)
       rack (>= 1.3)
-    rails (6.1.7.6)
-      actioncable (= 6.1.7.6)
-      actionmailbox (= 6.1.7.6)
-      actionmailer (= 6.1.7.6)
-      actionpack (= 6.1.7.6)
-      actiontext (= 6.1.7.6)
-      actionview (= 6.1.7.6)
-      activejob (= 6.1.7.6)
-      activemodel (= 6.1.7.6)
-      activerecord (= 6.1.7.6)
-      activestorage (= 6.1.7.6)
-      activesupport (= 6.1.7.6)
-      bundler (>= 1.15.0)
-      railties (= 6.1.7.6)
-      sprockets-rails (>= 2.0.0)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -216,12 +228,6 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    railties (6.1.7.6)
-      actionpack (= 6.1.7.6)
-      activesupport (= 6.1.7.6)
-      method_source
-      rake (>= 12.2)
-      thor (~> 1.0)
     rake (13.0.6)
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
@@ -325,7 +331,7 @@ DEPENDENCIES
   pry-rescue
   pry-stack_explorer
   puma (~> 5.6)
-  rails (~> 6.1.4, >= 6.1.4.6)
+  rails!
   rexml
   rspec-rails (~> 5.1.2)
   sass-rails (>= 6.0.0)


### PR DESCRIPTION
Rails is not going to officially release a backport of a fix from Rails 7 that would enable `good_job` to work with Rails 6.1.x and Ruby 3.2.x. See https://github.com/bensheldon/good_job/issues/1016#issuecomment-1644915406. 

We are now pointing at the 6-1-stable branch instead of a specific release, at least until we can upgrade to Rails 7.x.