### PR TITLE
Separate setup from deploy

### DIFF
--- a/.cloud-gov/deploy.sh
+++ b/.cloud-gov/deploy.sh
@@ -1,62 +1,25 @@
 #!/bin/sh
+
 #
-# This script will attempt to create the services required
-# and then launch everything.
+# This script will deploy apps to spaces where services are already configured
+# The script assumes that the calling user is already authenticated and
+# targeting the intended space
 #
 
 set -e 
+
+CF_ORG=${CF_ORG:-gsa-tts-identity-prototyping}
 
 # This is the hostname for the route set for the app
 CGHOSTNAME="${CGHOSTNAME:-all-sorns}"
 
 echo "$CGHOSTNAME"
 
-cf api https://api.fr.cloud.gov
-cf auth "$CF_USERNAME" "$CF_PASSWORD"
-cf target -o "$CF_ORG" -s "$CF_SPACE"
-
-# function to check if a service exists
-service_exists()
-{
-  cf service "$1" >/dev/null 2>&1
-}
-
-if [ "$1" = "setup" ] ; then  echo
-	# create services (if needed)
-
-	if service_exists "all-sorns-deployer" ; then
-	  echo all-sorns-deployer already created
-	else
-	  cf create-service cloud-gov-service-account space-deployer all-sorns-keys
-	  cf create-service-key all-sorns-keys deployer
-	  echo "to get the CF_USERNAME and CF_PASSWORD, execute 'cf service-key all-sorns-keys deployer'"
-	fi
-
-	if service_exists "all-sorns-db" ; then
-	  echo all-sorns-db DB already created
-	else
-        cf create-service aws-rds small-psql all-sorns-db
-            echo sleeping until db is awake
-            for i in 1 2 3 ; do
-				sleep 60
-				echo $i minutes...
-			done
-	fi
-
-	# set up app
-	if cf app all_sorns >/dev/null 2>&1 ; then
-		echo all_sorns app already set up
-	else
-		cf create-app all_sorns
-		cf apply-manifest -f ".cloud-gov/manifest-${CF_SPACE}.yml"
-	fi
-fi
-
 # launch the app
 if [ "$1" = "rolling" ] ; then
 	# Do a zero downtime deploy.  This requires enough memory for
 	# two apps to exist in the org/space at one time.
-	cf push all_sorns --no-route -f ".cloud-gov/manifest-${CF_SPACE}.yml" --strategy rolling || exit 1
+	cf push all_sorns -f ".cloud-gov/manifest-${CF_SPACE}.yml" --no-route --strategy rolling || exit 1
 else
 	cf push all_sorns -f ".cloud-gov/manifest-${CF_SPACE}.yml" --no-route
 fi
@@ -68,6 +31,6 @@ if [ "${CF_ORG}" = "all-sorn-prod" ] ; then
 fi
 # tell people where to go
 echo
+echo "To log into the site, go to https://${CGHOSTNAME}.app.cloud.gov/"
 echo
-echo "to log into the site, you will want to go to https://${CGHOSTNAME}.app.cloud.gov/"
-echo 'Have fun!'
+

--- a/.cloud-gov/setup.sh
+++ b/.cloud-gov/setup.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# This script will create the services required and then launch everything. It
+# is idempotent; it can be run again with the same arguments.
+
+# It's expected that the target space and corresponding -public space exist.
+# It's expected to be run by someone with the SpaceDeveloper role on both spaces.
+
+# Error out if anything goes wrong.
+set -e 
+
+CF_ORG="${CF_ORG:-gsa-tts-identity-prototyping}"
+CF_SPACE="${1:-all-sorn-test}"
+
+echo "Setting up ${CF_ORG}/${CF_SPACE}..."
+
+# function to check if a service exists
+service_exists()
+{
+  cf service "$1" >/dev/null 2>&1
+}
+
+if service_exists "all-sorns-deployer" ; then
+    echo all-sorns-deployer already created
+else
+    cf create-service cloud-gov-service-account space-deployer all-sorns-keys
+    cf create-service-key all-sorns-keys deployer
+    deployeruser=$(cf service-key all-sorns-keys deployer | tail -n +3 | jq -r .credentials.username)
+    cf set-space-role ${deployeruser} ${CF_ORG} ${CF_SPACE}-public SpaceDeveloper
+    echo "To get the CF_USERNAME and CF_PASSWORD, execute 'cf service-key all-sorns-keys deployer'"
+    echo "You will want to include these secrets in your CI/CD pipeline"
+    echo
+fi
+
+# Remove public egress from the target space while running
+cf unbind-security-group public_networks_egress ${CF_ORG} ${CF_SPACE} --lifecycle running
+
+# Add public egress to the corresponding -public space while running
+cf bind-security-group public_networks_egress ${CF_ORG} --space ${CF_SPACE}-public --lifecycle running 
+
+exit
+
+if service_exists "all-sorns-db" ; then
+    echo all-sorns-db DB already created
+else
+    cf create-service aws-rds small-psql all-sorns-db
+        echo sleeping until db is awake
+        for i in 1 2 3 ; do
+            sleep 60
+            echo $i minutes...
+        done
+fi
+
+
+
+# set up app
+if cf app all_sorns >/dev/null 2>&1 ; then
+    echo all_sorns app already set up
+else
+    cf create-app all_sorns
+    cf apply-manifest -f ".cloud-gov/manifest-${CF_SPACE}.yml"
+fi

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,16 +12,15 @@ jobs:
     if: github.repository_owner == '18F' && ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Deploy to cloud.gov prod space
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
-      - name: Install cf cli
-        run: |
-          curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v7&source=github" | sudo tar -zx --directory=/usr/local/bin
-          cf --version
-      - name: Deploy to cloud.gov
-        env:
-          CF_USERNAME: ${{ secrets.CF_USERNAME }}
-          CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-          CF_ORG: ${{ secrets.CF_ORG }}
-          CF_SPACE: ${{ secrets.CF_SPACE }}
-        run: ./.cloud-gov/deploy.sh rolling
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Deploy app
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          cf_username: ${{ secrets.CF_USERNAME }}
+          cf_password: ${{ secrets.CF_PASSWORD }}
+          cf_org: ${{ secrets.CF_ORG }}
+          cf_space: ${{ secrets.CF_SPACE }}
+          cf_command: CF_SPACE=${{ secrets.CF_SPACE }} CGHOSTNAME=all-sorns .cloud-gov/deploy.sh rolling

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -12,17 +12,15 @@ jobs:
     if: github.repository_owner == '18F' && ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Deploy to cloud.gov test space
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
-      - name: Install cf cli
-        run: |
-          curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v7&source=github" | sudo tar -zx --directory=/usr/local/bin
-          cf --version
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Deploy app
-        env:
-          CF_USERNAME: ${{ secrets.CF_USERNAME_TEST }}
-          CF_PASSWORD: ${{ secrets.CF_PASSWORD_TEST }}
-          CF_ORG: ${{ secrets.CF_ORG }}
-          CF_SPACE: ${{ secrets.CF_SPACE_TEST }}
-          CGHOSTNAME: all-sorns-test
-        run: ./.cloud-gov/deploy.sh rolling
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          cf_username: ${{ secrets.CF_USERNAME_TEST }}
+          cf_password: ${{ secrets.CF_PASSWORD_TEST }}
+          cf_org: ${{ secrets.CF_ORG }}
+          cf_space: ${{ secrets.CF_SPACE_TEST }}
+          cf_command: CF_SPACE=${{ secrets.CF_SPACE_TEST }} CGHOSTNAME=all-sorns-test .cloud-gov/deploy.sh rolling


### PR DESCRIPTION
Since it needs to set up deployer accounts and give them permission on multiple spaces, the space and service setup has been factored out and is expected to be run manually rather than during CI/CD. (This also makes it a good candidate for being managed by Terraform.)